### PR TITLE
feat: Added quantity of shares to user stocks table

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,4 @@ omit =
 
 [report]
 show_missing = True
+fail_under = 80

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,16 @@ repos:
       - id: pytest # unit tests
         name: pytest
         description: "Pytest: Helps you write less buggy code"
-        entry: pipenv run pytest
+        entry: pipenv run coverage run -m pytest
+        language: python
+        types: [ python ]
+        pass_filenames: false
+        always_run: true
+
+      - id: coverage # test coverage
+        name: coverage
+        description: "Coverage: A tool for measuring code coverage of Python programs"
+        entry: pipenv run coverage report -m
         language: python
         types: [ python ]
         pass_filenames: false

--- a/src/database/userstocks/models.py
+++ b/src/database/userstocks/models.py
@@ -3,8 +3,17 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class UserStock:
+    """
+    UserStock Model
+
+    This class is responsible for maintaining the many-to-many relationship between
+    users and stocks. This model contains user to stock mappings with each of their
+    primary keys to store user portfolios.
+    """
+
     user_email: str
     stock_symbol: str
+    quantity: float
 
     def to_ddb_item(self) -> dict:
         return {
@@ -12,4 +21,5 @@ class UserStock:
                 "S": self.user_email,
             },
             "stock_symbol": {"S": self.stock_symbol},
+            "quantity": {"N": str(self.quantity)},
         }

--- a/src/database/userstocks/table.py
+++ b/src/database/userstocks/table.py
@@ -12,6 +12,17 @@ log = Logger(__name__).get_logger()
 
 @dataclass
 class UsersStocksTable:
+    """
+    UsersStocks Table
+
+    This table maintains mappings from users to stocks to store
+    user portfolios.
+
+    Item Schema
+    - user_email (HASH key): The primary key of the user.
+    - stock_symbol (RANGE key): The primary key of the stock.
+    - quantity: The quantity of the stock owned by the user.
+    """
 
     TABLE_NAME_FORMAT = "UsersStocks-{domain}"
 
@@ -25,6 +36,15 @@ class UsersStocksTable:
         log.debug(f"Creating UsersStocks table DDB client for table '{self.table}'")
 
     def get_stocks_for_user(self, user: User) -> List[UserStock]:
+        """
+        Get the stocks owned by a user.
+
+        Args:
+            user: The user to get the stocks.
+
+        Returns:
+            The stocks owned by the user.
+        """
         log.info(f"Getting stocks for user '{user.email}' from table '{self.table}'")
         stocks = []
         for item in self.ddb.query(
@@ -50,5 +70,7 @@ class UsersStocksTable:
     @staticmethod
     def _get_user_stock_from_ddb_item(item: dict) -> UserStock:
         return UserStock(
-            user_email=item["user_email"]["S"], stock_symbol=item["stock_symbol"]["S"]
+            user_email=item["user_email"]["S"],
+            stock_symbol=item["stock_symbol"]["S"],
+            quantity=float(item["quantity"]["N"]),
         )

--- a/tst/conftest.py
+++ b/tst/conftest.py
@@ -93,6 +93,7 @@ def ddb_client() -> DynamoDBClient:
                     Item=UserStock(
                         user_email=json_userstock["user_email"],
                         stock_symbol=json_userstock["stock_symbol"],
+                        quantity=json_userstock["quantity"],
                     ).to_ddb_item(),
                 )
 

--- a/tst/database/test_user_stocks_table.py
+++ b/tst/database/test_user_stocks_table.py
@@ -2,16 +2,33 @@ from src.database.users.models import User
 from src.database.userstocks.models import UserStock
 from src.database.userstocks.table import UsersStocksTable
 
-USER = User(email="walteraifinancialadvisor@gmail.com", username="walter")
-USER_STOCKS = [
-    UserStock(user_email=USER.email, stock_symbol="AAPL"),
-    UserStock(user_email=USER.email, stock_symbol="AMZN"),
-    UserStock(user_email=USER.email, stock_symbol="MSFT"),
-    UserStock(user_email=USER.email, stock_symbol="NFLX"),
-    UserStock(user_email=USER.email, stock_symbol="PYPL"),
+################
+# USERS STOCKS #
+################
+
+WALTER = User(email="walter@gmail.com", username="walter")
+WALRUS = User(email="walrus@gmail.com", username="walrus")
+
+WALTER_STOCKS = [
+    UserStock(user_email=WALTER.email, stock_symbol="AAPL", quantity=1.0),
+    UserStock(user_email=WALTER.email, stock_symbol="AMZN", quantity=1.5),
+    UserStock(user_email=WALTER.email, stock_symbol="MSFT", quantity=2.0),
+    UserStock(user_email=WALTER.email, stock_symbol="NFLX", quantity=10.0),
+    UserStock(user_email=WALTER.email, stock_symbol="PYPL", quantity=10.0),
 ]
+WALRUS_STOCKS = [
+    UserStock(user_email=WALRUS.email, stock_symbol="AMZN", quantity=100.0),
+    UserStock(user_email=WALRUS.email, stock_symbol="MSFT", quantity=100.0),
+    UserStock(user_email=WALRUS.email, stock_symbol="NFLX", quantity=100.0),
+]
+
+#########
+# TESTS #
+#########
 
 
 def test_get_user_stocks(users_stocks_table: UsersStocksTable) -> None:
-    user_stocks = users_stocks_table.get_stocks_for_user(USER)
-    assert set(user_stocks) == set(USER_STOCKS)
+    walter_stocks = users_stocks_table.get_stocks_for_user(WALTER)
+    walrus_stocks = users_stocks_table.get_stocks_for_user(WALRUS)
+    assert set(walter_stocks) == set(WALTER_STOCKS)
+    assert set(walrus_stocks) == set(WALRUS_STOCKS)

--- a/tst/database/test_users_table.py
+++ b/tst/database/test_users_table.py
@@ -1,6 +1,17 @@
 from src.database.users.models import User
 
-USERS = [User(email="walteraifinancialadvisor@gmail.com", username="walter")]
+#########
+# USERS #
+#########
+
+USERS = [
+    User(email="walter@gmail.com", username="walter"),
+    User(email="walrus@gmail.com", username="walrus"),
+]
+
+#########
+# TESTS #
+#########
 
 
 def test_get_users(users_table) -> None:

--- a/tst/users.jsonl
+++ b/tst/users.jsonl
@@ -1,1 +1,2 @@
-{"email":  "walteraifinancialadvisor@gmail.com", "username":  "walter"}
+{"email":  "walter@gmail.com", "username":  "walter"}
+{"email":  "walrus@gmail.com", "username":  "walrus"}

--- a/tst/usersstocks.jsonl
+++ b/tst/usersstocks.jsonl
@@ -1,5 +1,8 @@
-{"user_email": "walteraifinancialadvisor@gmail.com", "stock_symbol": "AAPL"}
-{"user_email": "walteraifinancialadvisor@gmail.com", "stock_symbol": "AMZN"}
-{"user_email": "walteraifinancialadvisor@gmail.com", "stock_symbol": "MSFT"}
-{"user_email": "walteraifinancialadvisor@gmail.com", "stock_symbol": "NFLX"}
-{"user_email": "walteraifinancialadvisor@gmail.com", "stock_symbol": "PYPL"}
+{"user_email": "walter@gmail.com", "stock_symbol": "AAPL", "quantity": 1.0}
+{"user_email": "walter@gmail.com", "stock_symbol": "AMZN", "quantity": 1.5}
+{"user_email": "walter@gmail.com", "stock_symbol": "MSFT", "quantity": 2.0}
+{"user_email": "walter@gmail.com", "stock_symbol": "NFLX", "quantity": 10.0}
+{"user_email": "walter@gmail.com", "stock_symbol": "PYPL", "quantity": 10.0}
+{"user_email": "walrus@gmail.com", "stock_symbol": "AMZN", "quantity": 100.0}
+{"user_email": "walrus@gmail.com", "stock_symbol": "MSFT", "quantity": 100.0}
+{"user_email": "walrus@gmail.com", "stock_symbol": "NFLX", "quantity": 100.0}


### PR DESCRIPTION
This PR adds quantity to the `UsersStocks` table to record the number of shares owned by a user. This helps to calculate the user's total portfolio value and also implements Issue #39. 

This PR also adds a coverage check to the `.pre-commit-config.yaml` that will fail commits with test coverage below 80%... Time to start enforcing good testing practices!