### PR TITLE
feat: Generate and upload Codecov report on pushes to main

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
This PR refactors the GitHub action to generate and upload Codecov reports on pushes to `main` branch.

Currently, the action is only configured to generate/upload reports to Codecov on pull requests to `main`. This results in the Codecov UI only have coverage metrics for branches that were eventually merged into `main`. 

Most importantly, Walter should have continuous code coverage metrics on the `main` branch as that is the release branch that can be monitored for improvement as the codebase grows. 

Unit tests are important 🥇 