### PR TITLE
feat: Add DB API for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ After getting the answers to the prompts given in the `templatespec.yml` file, W
 
 Use the following commands to create/update/delete the [CloudFormation](https://aws.amazon.com/cloudformation/) stacks responsible for `WalterAIBackend` infrastructure by domain.
 
-```
+```bash
 # create development stack
 aws cloudformation create-stack \
   --stack-name="WalterAIBackend-dev" \
@@ -70,11 +70,11 @@ aws cloudformation delete-stack \
 
 #### Lambda
 
-Use the following command to dump the required Python dependencies to a directory to zip and upload to AWS as a [Lambda Layer](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html).
+Use the following command to dump the required Python dependencies listed in the `Pipfile` to a directory to zip and upload to AWS as a [Lambda Layer](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html).
 
-A new Lambda Layer is required to be created and uploaded to AWS anytime a new runtime dependency is added to `WalterAIBackend`. To ensure the deployed Lambda utilizes the new Lambda Layer, the corresponding CloudFormation stacks need to be updated to increment the Lambda Layer utilized by `WalterAIBackend`. 
+A new Lambda Layer is required to be created and uploaded to AWS anytime a new runtime dependency is added to Walter. To ensure the deployed Lambda utilizes the new Lambda Layer, the corresponding CloudFormation stacks need to be updated to increment the Lambda Layer utilized by `WalterAPI` and `WalterBackend`. 
 
-```
+```bash
 mkdir python \
 && pipenv requirements > requirements.txt \
 && pip3 install -r requirements.txt --platform manylinux2014_aarch64 --target ./python --only-binary=:all: --upgrade \
@@ -87,6 +87,44 @@ mkdir python \
 && rm -rf python* \
 && rm -rf requirements.txt
 ```
+
+Use the following command to update the Walter backend code for `WalterAPI` and `WalterBackend` from the latest artifacts in S3.
+
+```bash
+echo Updating WalterAPI source code with artifact from S3 \
+&& aws lambda update-function-code --function-name WalterAPI-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip \
+&& echo Updating WalterBackend source code with artifact from S3 \
+&& aws lambda update-function-code --function-name WalterBackend-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip
+```
+
+Use the following command to publish new versions for the `WalterAPI` and `WalterBackend` lambda functions. 
+
+```bash
+echo Publishing new WalterAPI Lambda version \
+&& aws lambda publish-version --function-name WalterAPI-dev \
+&& echo Publishing new WalterBackend Lambda version \
+&& aws lambda publish-version --function-name WalterBackend-dev
+```
+
+### S3
+
+Use the following command to update the source code of Walter backend.
+
+```bash
+echo "Updating Walter backend source code" \
+&& mkdir walter-backend \
+&& cp -r src walter-backend \
+&& cp config.yml walter-backend \
+&& cp api.py walter-backend \
+&& cp walter.py walter-backend \
+&& cd walter-backend \
+&& zip -r ../walter-backend.zip . \
+&& cd .. \
+&& echo "Publishing Walter backend source to S3" \
+&& aws s3 cp walter-backend.zip s3://walter-backend-src/walter-backend.zip
+```
+The CloudFormation stack responsible for creating the `WalterAPI` and `WalterBackend` Lambdas pulls the source  code
+from S3 and the above command zips the required source code files in this repository into a package to upload to S3. 
 
 #### SQS
 

--- a/api.py
+++ b/api.py
@@ -1,0 +1,5 @@
+import json
+
+
+def lambda_handler(event, context) -> dict:
+    return {"statusCode": 200, "body": json.dumps("WalterAPI")}

--- a/buildspec.py
+++ b/buildspec.py
@@ -102,13 +102,19 @@ def delete_change_set(client: CloudFormationClient) -> None:
 
 cloudformation = boto3.client("cloudformation", region_name=REGION)
 
+print(f"Checking if stack '{STACK_NAME}' exists...")
 if stack_exists(cloudformation):
+    print(f"Stack '{STACK_NAME}' exists! Creating change set...")
     create_change_set(cloudformation)
     status = describe_change_set(cloudformation)
+    print(f"Change set status: {status}")
 
     if change_set_contains_changes(status):
+        print("Change set contains changes! Executing change set...")
         execute_change_set(cloudformation)
 
+    print("Deleting change set...")
     delete_change_set(cloudformation)
 else:
+    print(f"Stack '{STACK_NAME}' does not exist! Creating stack...")
     create_stack(cloudformation)

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -12,28 +12,34 @@ phases:
       - pip install mypy-boto3-lambda
   pre_build:
     commands:
-    - echo Updating WalterAIBackend infrastructure via CloudFormation
+    - echo Updating Walter backend infrastructure via CloudFormation
     - python buildspec.py
   build:
     commands:
-      - echo Updating WalterAIBackend source code
-      - mkdir walterai-backend
-      - cp -r src walterai-backend
-      - cp walter.py walterai-backend
-      - cd walterai-backend
-      - zip -r ../walterai-backend.zip .
+      - echo Updating Walter backend source code
+      - mkdir walter-backend
+      - cp -r src walter-backend
+      - cp config.yml walter-backend
+      - cp api.py walter-backend
+      - cp walter.py walter-backend
+      - cd walter-backend
+      - zip -r ../walter-backend.zip .
       - cd ..
-      - echo Dumping WalterAIBackend source code to S3
-      - aws s3 cp walterai-backend.zip s3://walterai-backend-src/walterai-backend.zip
-      - echo Updating WalterAIBackend Lambda code with artifact from S3
-      - aws lambda update-function-code --function-name WalterAIBackend-dev --s3-bucket walterai-backend-src --s3-key walterai-backend.zip
+      - echo Dumping Walter backend source code to S3
+      - aws s3 cp walter-backend.zip s3://walter-backend-src/walter-backend.zip
+      - echo Updating WalterAPI source code with artifact from S3
+      - aws lambda update-function-code --function-name WalterAPI-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip
+      - echo Updating WalterBackend source code with artifact from S3
+      - aws lambda update-function-code --function-name WalterBackend-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip
   post_build:
     commands:
-      - echo Sleeping 30 seconds for WalterAIBackend Lambda to finish updating
-      - sleep 30
-      - echo Publishing new WalterAIBackend Lambda version
-      - aws lambda publish-version --function-name WalterAIBackend-dev 
-      - echo Sleeping 30 seconds for new WalterAIBackend Lambda version to finish publishing
+      - echo Sleeping 60 seconds for Walter backend to finish updating
+      - sleep 60
+      - echo Publishing new WalterAPI Lambda version
+      - aws lambda publish-version --function-name WalterAPI-dev
+      - echo Publishing new WalterBackend Lambda version
+      - aws lambda publish-version --function-name WalterBackend-dev
+      - echo Sleeping 60 seconds for new Walter backend lambda versions to finish publishing
       - echo Creating AppSpec file for CodeDeploy
       - python appspec.py
 

--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -1,10 +1,10 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: "WalterAIBackend Infrastructure"
+Description: "Walter backend Infrastructure"
 
 Parameters:
   AppEnvironment:
     Type: String
-    Description: The environment of the WalterAIBackend stack
+    Description: The environment of the Walter backend stack
     Default: dev
     AllowedValues:
       - dev
@@ -17,26 +17,33 @@ Resources:
   ### LAMBDA ###
   ##############
 
-  WalterAIBackendFunctionAlias:
+  WalterBackendFunctionAlias:
     Type: AWS::Lambda::Alias
     Properties:
-      FunctionName: !Ref WalterAIBackendFunction
+      FunctionName: !Ref WalterBackendFunction
       FunctionVersion: $LATEST
-      Name: !Sub "WalterAIBackend-${AppEnvironment}"
+      Name: !Sub "WalterBackend-${AppEnvironment}"
 
-  WalterAIBackendFunctionEventSourceMapping:
+  WalterAPIFunctionAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Ref WalterAPIFunction
+      FunctionVersion: $LATEST
+      Name: !Sub "WalterAPI-${AppEnvironment}"
+
+  WalterBackendFunctionEventSourceMapping:
     Type: AWS::Lambda::EventSourceMapping
     Properties:
       BatchSize: 1
       EventSourceArn: !GetAtt NewsletterQueue.Arn
-      FunctionName: !GetAtt WalterAIBackendFunction.Arn
+      FunctionName: !GetAtt WalterBackendFunction.Arn
       Enabled: "True"
 
-  WalterAIBackendFunction:
+  WalterBackendFunction:
       Type: AWS::Lambda::Function
       Properties:
-        FunctionName: !Sub "WalterAIBackend-${AppEnvironment}"
-        Description: !Sub "WalterAIBackend Lambda (${AppEnvironment})"
+        FunctionName: !Sub "WalterBackend-${AppEnvironment}"
+        Description: !Sub "WalterBackend Lambda (${AppEnvironment})"
         Handler: walter.lambda_handler
         Role: !Join
           - ""
@@ -45,8 +52,8 @@ Resources:
             - ":role/"
             - !Ref WalterLambdaRole
         Code:
-          S3Bucket: walterai-backend-src
-          S3Key: walterai-backend.zip
+          S3Bucket: walter-backend-src
+          S3Key: walter-backend.zip
         Timeout: 60
         Runtime: python3.11
         Architectures:
@@ -59,10 +66,42 @@ Resources:
               - ":"
               - !Ref "AWS::AccountId"
               - ":layer:"
-              - "WalterAILambdaLayer:19"
+              - "WalterAILambdaLayer:20"
         Environment:
           Variables:
             DOMAIN: DEVELOPMENT
+
+  WalterAPIFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "WalterAPI-${AppEnvironment}"
+      Description: !Sub "WalterAPI Lambda (${AppEnvironment})"
+      Handler: api.lambda_handler
+      Role: !Join
+        - ""
+        - - "arn:aws:iam::"
+          - !Ref "AWS::AccountId"
+          - ":role/"
+          - !Ref WalterLambdaRole
+      Code:
+        S3Bucket: walter-backend-src
+        S3Key: walter-backend.zip
+      Timeout: 60
+      Runtime: python3.11
+      Architectures:
+        - "arm64"
+      Layers:
+        - !Join
+          - ""
+          - - "arn:aws:lambda:"
+            - !Ref "AWS::Region"
+            - ":"
+            - !Ref "AWS::AccountId"
+            - ":layer:"
+            - "WalterAILambdaLayer:20"
+      Environment:
+        Variables:
+          DOMAIN: DEVELOPMENT
 
   ################
   ### DYNAMODB ###
@@ -115,8 +154,8 @@ Resources:
   WalterLambdaRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "WalterAILambaExecutionRole-${AppEnvironment}"
-      Description: "Walter AI Lambda execution role"
+      RoleName: !Sub "WalterLambaExecutionRole-${AppEnvironment}"
+      Description: "Walter Lambda execution role"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -344,6 +383,7 @@ Resources:
 
   NewslettersBucket:
     Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
     Properties:
       BucketName: !Sub "walterai-newsletters-${AppEnvironment}"
       BucketEncryption:
@@ -378,6 +418,7 @@ Resources:
 
   TemplatesBucket:
     Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
     Properties:
       BucketName: !Sub "walterai-templates-${AppEnvironment}"
       BucketEncryption:

--- a/src/aws/dynamodb/client.py
+++ b/src/aws/dynamodb/client.py
@@ -110,3 +110,23 @@ class WalterDDBClient:
                 f"Unexpected error occurred attempting to scan table '{table}'!\n"
                 f"Error: {error.response['Error']['Message']}"
             )
+
+    def delete_item(self, table: str, key: dict) -> None:
+        """
+        Delete an item, if it exists, from the DDB table given its primary key.
+
+        Args:
+            table: The name of the DDB table to delete the item.
+            key: The primary key of the item to delete.
+
+        Returns:
+            None
+        """
+        log.debug(f"Deleting item from table '{table}' with key:\n{key}")
+        try:
+            self.client.delete_item(TableName=table, Key=key)
+        except ClientError as error:
+            log.error(
+                f"Unexpected error occurred attempting to delete item from table '{table}'!\n"
+                f"Error: {error.response['Error']['Message']}"
+            )

--- a/src/database/client.py
+++ b/src/database/client.py
@@ -28,8 +28,17 @@ class WalterDB:
         self.stocks_table = StocksTable(self.ddb, self.domain)
         self.users_stocks_table = UsersStocksTable(self.ddb, self.domain)
 
+    def create_user(self, user: User) -> None:
+        self.users_table.create_user(user)
+
     def get_user(self, email: str) -> User:
         return self.users_table.get_user(email)
+
+    def update_user(self, user: User) -> None:
+        self.users_table.update_user(user)
+
+    def delete_user(self, email: str) -> None:
+        self.users_table.delete_user(email)
 
     def get_stocks_for_user(self, user: User) -> Dict[str, UserStock]:
         stocks = self.users_stocks_table.get_stocks_for_user(user)

--- a/src/database/users/table.py
+++ b/src/database/users/table.py
@@ -26,11 +26,26 @@ class UsersTable:
         self.table = UsersTable._get_table_name(self.domain)
         log.debug(f"Creating UsersTable DDB client with table name '{self.table}'")
 
+    def create_user(self, user: User) -> None:
+        log.info(
+            f"Creating the following user and adding to table '{self.table}':\n{user}"
+        )
+        item = user.to_ddb_item()
+        self.ddb.put_item(self.table, item)
+
     def get_user(self, email: str) -> User:
         log.info(f"Getting user with email '{email}' from table '{self.table}'")
         key = UsersTable._get_user_key(email)
         item = self.ddb.get_item(self.table, key)
         return UsersTable._get_user_from_ddb_item(item)
+
+    def update_user(self, user: User) -> None:
+        log.info(f"Updating user with email '{user.email}'")
+        self.ddb.put_item(self.table, user.to_ddb_item())
+
+    def delete_user(self, email: str) -> None:
+        log.info(f"Deleting user with email '{email}'")
+        self.ddb.delete_item(self.table, UsersTable._get_user_key(email))
 
     def get_users(self) -> List[User]:
         log.info(f"Getting users from table '{self.table}'")

--- a/walter.py
+++ b/walter.py
@@ -69,8 +69,9 @@ def lambda_handler(event, context) -> dict:
             cloudwatch.emit_metric_number_of_stocks_analyzed(len(stocks))
         else:
             log.info("Not emitting metrics")
+
     except Exception:
         sqs.delete_event(event.receipt_handle)
     sqs.delete_event(event.receipt_handle)
 
-    return {"statusCode": 200, "body": json.dumps("WalterAIBackend")}
+    return {"statusCode": 200, "body": json.dumps("WalterBackend")}


### PR DESCRIPTION
This PR adds a new Lambda function `WalterAPI` that will be used by the frontend to interact with the DB.

Insert users, update portfolios, etc. The frontend will have forms to call the endpoints served by `WalterAPI`.

I thought it was better to create a new Lambda rather than add differentiating logic to `WalterBackend` to also respond to frontend requests.

So, the two Lambdas are designed to serve entirely different purposes hence their separation:

* `WalterAPI` - Serve frontend requests behind API Gateway for Walter's frontend
* `WalterBackend` - Process newsletter requests in the Newsletter SQS queue and send emails

Will need to add an additional Lambda that serves the purpose of sending newsletter requests to SQS at 7:00am every day to trigger `WalterBackend`. 

That should be it for V1 Walter backend! 🚀 