### PR TITLE
feat: Separate WalterAPI and WalterBackend IAM roles and update CFN

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,21 +51,21 @@ Use the following commands to create/update/delete the [CloudFormation](https://
 ```bash
 # create development stack
 aws cloudformation create-stack \
-  --stack-name="WalterAIBackend-dev" \
+  --stack-name="WalterBackend-dev" \
   --template-body="file://infra/infra.yml" \
   --parameters="ParameterKey=AppEnvironment,ParameterValue=dev" \
   --capabilities="CAPABILITY_NAMED_IAM"
 
 # update development stack
 aws cloudformation update-stack \
-  --stack-name="WalterAIBackend-dev" \
+  --stack-name="WalterBackend-dev" \
   --template-body="file://infra/infra.yml" \
   --parameters="ParameterKey=AppEnvironment,ParameterValue=dev" \
   --capabilities="CAPABILITY_NAMED_IAM"
 
 # delete development stack
 aws cloudformation delete-stack \
-  --stack-name="WalterAIBackend-Dev"
+  --stack-name="WalterBackend-Dev"
 ```
 
 #### Lambda

--- a/appspec.py
+++ b/appspec.py
@@ -28,8 +28,8 @@ Resources:
   - MyFunction:
       Type: AWS::Lambda::Function
       Properties:
-        Name: "WalterAIBackend-{domain}"
-        Alias: "WalterAIBackend-{domain}"
+        Name: "WalterBackend-{domain}"
+        Alias: "WalterBackend-{domain}"
         CurrentVersion: "{current_walter_backend__version}"
         TargetVersion: "{target_walter_backend_version}"
 
@@ -50,9 +50,9 @@ DOMAIN = get_domain(os.getenv("DOMAIN", "DEVELOPMENT"))
 
 REGION = os.getenv("AWS_REGION", "us-east-1")
 
-WALTER_BACKEND_LAMBDA_NAME = f"WalterAIBackend-{DOMAIN.value}"
+WALTER_BACKEND_LAMBDA_NAME = f"WalterBackend-{DOMAIN.value}"
 
-WALTER_BACKEND_LAMBDA_ALIAS = f"WalterAIBackend-{DOMAIN.value}"
+WALTER_BACKEND_LAMBDA_ALIAS = f"WalterBackend-{DOMAIN.value}"
 
 WALTER_API_LAMBDA_NAME = f"WalterAPI-{DOMAIN.value}"
 

--- a/buildspec.py
+++ b/buildspec.py
@@ -26,11 +26,11 @@ DOMAIN = get_domain(os.getenv("DOMAIN", "DEVELOPMENT"))
 
 REGION = os.getenv("AWS_REGION", "us-east-1")
 
-STACK_NAME = f"WalterAIBackend-{DOMAIN.value}"
+STACK_NAME = f"WalterBackend-{DOMAIN.value}"
 
 CLOUDFORMATION_TEMPLATE = "./infra/infra.yml"
 
-CHANGE_SET_NAME = f"WalterAIBackendChangeSet-{DOMAIN.value}"
+CHANGE_SET_NAME = f"WalterBackendChangeSet-{DOMAIN.value}"
 
 ###########
 # METHODS #

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -12,11 +12,11 @@ phases:
       - pip install mypy-boto3-lambda
   pre_build:
     commands:
-    - echo Updating Walter backend infrastructure via CloudFormation
+    - echo Updating WalterBackend infrastructure via CloudFormation
     - python buildspec.py
   build:
     commands:
-      - echo Updating Walter backend source code
+      - echo Updating WalterBackend source code
       - mkdir walter-backend
       - cp -r src walter-backend
       - cp config.yml walter-backend
@@ -33,7 +33,7 @@ phases:
       - aws lambda update-function-code --function-name WalterBackend-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip
   post_build:
     commands:
-      - echo Sleeping 60 seconds for Walter backend to finish updating
+      - echo Sleeping 60 seconds for WalterBackend to finish updating
       - sleep 60
       - echo Publishing new WalterAPI Lambda version
       - aws lambda publish-version --function-name WalterAPI-dev

--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -1,5 +1,9 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: "Walter backend Infrastructure"
+Description: "WalterBackend infrastructure"
+
+##################
+### PARAMETERS ###
+##################
 
 Parameters:
   AppEnvironment:
@@ -11,46 +15,64 @@ Parameters:
       - preprod
       - prod
 
+#################
+### RESOURCES ###
+#################
+
 Resources:
 
   ##############
   ### LAMBDA ###
   ##############
 
-  WalterBackendFunctionAlias:
+  WalterAPIAlias:
     Type: AWS::Lambda::Alias
     Properties:
-      FunctionName: !Ref WalterBackendFunction
-      FunctionVersion: $LATEST
-      Name: !Sub "WalterBackend-${AppEnvironment}"
-
-  WalterAPIFunctionAlias:
-    Type: AWS::Lambda::Alias
-    Properties:
-      FunctionName: !Ref WalterAPIFunction
+      FunctionName: !Ref WalterAPI
       FunctionVersion: $LATEST
       Name: !Sub "WalterAPI-${AppEnvironment}"
 
-  WalterBackendFunctionEventSourceMapping:
-    Type: AWS::Lambda::EventSourceMapping
+  WalterBackendAlias:
+    Type: AWS::Lambda::Alias
     Properties:
-      BatchSize: 1
-      EventSourceArn: !GetAtt NewsletterQueue.Arn
-      FunctionName: !GetAtt WalterBackendFunction.Arn
-      Enabled: "True"
+      FunctionName: !Ref WalterBackend
+      FunctionVersion: $LATEST
+      Name: !Sub "WalterBackend-${AppEnvironment}"
 
-  WalterBackendFunction:
+  WalterAPI:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "WalterAPI-${AppEnvironment}"
+      Description: !Sub "WalterAPI function to interact with WalterDB and WalterBackend (${AppEnvironment})"
+      Handler: api.lambda_handler
+      Role: !GetAtt WalterAPIRole.Arn
+      Code:
+        S3Bucket: walter-backend-src
+        S3Key: walter-backend.zip
+      Timeout: 60
+      Runtime: python3.11
+      Architectures:
+        - "arm64"
+      Layers:
+        - !Join
+          - ""
+          - - "arn:aws:lambda:"
+            - !Ref "AWS::Region"
+            - ":"
+            - !Ref "AWS::AccountId"
+            - ":layer:"
+            - "WalterAILambdaLayer:20"
+      Environment:
+        Variables:
+          DOMAIN: DEVELOPMENT
+
+  WalterBackend:
       Type: AWS::Lambda::Function
       Properties:
         FunctionName: !Sub "WalterBackend-${AppEnvironment}"
-        Description: !Sub "WalterBackend Lambda (${AppEnvironment})"
+        Description: !Sub "WalterBackend function to read from WalterDB and write and send newsletters (${AppEnvironment})"
         Handler: walter.lambda_handler
-        Role: !Join
-          - ""
-          - - "arn:aws:iam::"
-            - !Ref "AWS::AccountId"
-            - ":role/"
-            - !Ref WalterLambdaRole
+        Role: !GetAtt WalterBackendRole.Arn
         Code:
           S3Bucket: walter-backend-src
           S3Key: walter-backend.zip
@@ -71,37 +93,13 @@ Resources:
           Variables:
             DOMAIN: DEVELOPMENT
 
-  WalterAPIFunction:
-    Type: AWS::Lambda::Function
+  WalterBackendFunctionEventSourceMapping:
+    Type: AWS::Lambda::EventSourceMapping
     Properties:
-      FunctionName: !Sub "WalterAPI-${AppEnvironment}"
-      Description: !Sub "WalterAPI Lambda (${AppEnvironment})"
-      Handler: api.lambda_handler
-      Role: !Join
-        - ""
-        - - "arn:aws:iam::"
-          - !Ref "AWS::AccountId"
-          - ":role/"
-          - !Ref WalterLambdaRole
-      Code:
-        S3Bucket: walter-backend-src
-        S3Key: walter-backend.zip
-      Timeout: 60
-      Runtime: python3.11
-      Architectures:
-        - "arm64"
-      Layers:
-        - !Join
-          - ""
-          - - "arn:aws:lambda:"
-            - !Ref "AWS::Region"
-            - ":"
-            - !Ref "AWS::AccountId"
-            - ":layer:"
-            - "WalterAILambdaLayer:20"
-      Environment:
-        Variables:
-          DOMAIN: DEVELOPMENT
+      BatchSize: 1
+      EventSourceArn: !GetAtt NewslettersQueue.Arn
+      FunctionName: !GetAtt WalterBackend.Arn
+      Enabled: "True"
 
   ################
   ### DYNAMODB ###
@@ -151,11 +149,28 @@ Resources:
   ### IAM ROLES ###
   #################
 
-  WalterLambdaRole:
+  WalterAPIRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "WalterLambaExecutionRole-${AppEnvironment}"
-      Description: "Walter Lambda execution role"
+      RoleName: !Sub "WalterAPIRole-${AppEnvironment}"
+      Description: "WalterAPI execution role to read and modify WalterDB and send newsletters (${AppEnvironment})"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action:
+              - "sts:AssumeRole"
+            Effect: Allow
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+  WalterBackendRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "WalterBackendRole-${AppEnvironment}"
+      Description: "WalterBackend execution role write and send newsletters (${AppEnvironment})"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -184,7 +199,7 @@ Resources:
               - "bedrock:InvokeModel"
             Resource: "arn:aws:bedrock:us-east-1::foundation-model/meta.llama3-70b-instruct-v1:0"
       Roles:
-        - !Ref WalterLambdaRole
+        - !Ref WalterBackendRole
   
   CloudWatchAccessPolicy:
     Type: AWS::IAM::Policy
@@ -198,7 +213,8 @@ Resources:
               - "cloudwatch:PutMetricData"
             Resource: "*"
       Roles:
-        - !Ref WalterLambdaRole
+        - !Ref WalterAPIRole
+        - !Ref WalterBackendRole
 
   NewslettersBucketAccessPolicy:
     Type: AWS::IAM::Policy
@@ -210,18 +226,14 @@ Resources:
           - Effect: Allow
             Action:
               - "s3:PutObject"
-            Resource: !Join
-              - ""
-              - - "arn:aws:s3:::"
-                - !Ref NewslettersBucket
-                - "/*" 
+            Resource: !Sub "${NewslettersBucket.Arn}/*"
       Roles:
-        - !Ref WalterLambdaRole
+        - !Ref WalterBackendRole
 
   NewslettersQueueAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub "NewsletterQueueAccessPolicy-${AppEnvironment}"
+      PolicyName: !Sub "NewslettersQueueAccessPolicy-${AppEnvironment}"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -230,9 +242,9 @@ Resources:
               - "sqs:ReceiveMessage"
               - "sqs:DeleteMessage"
               - "sqs:GetQueueAttributes"
-            Resource: !GetAtt NewsletterQueue.Arn
+            Resource: !GetAtt NewslettersQueue.Arn
       Roles:
-        - !Ref WalterLambdaRole
+        - !Ref WalterBackendRole
 
   SecretsManagerAccessPolicy:
     Type: AWS::IAM::Policy
@@ -252,7 +264,8 @@ Resources:
                 - !Ref "AWS::AccountId"
                 - ":secret:PolygonAPIKey-vZymuJ"
       Roles:
-        - !Ref WalterLambdaRole
+        - !Ref WalterAPIRole
+        - !Ref WalterBackendRole
 
   SimpleEmailSerivceAccessPolicy:
     Type: AWS::IAM::Policy
@@ -266,7 +279,7 @@ Resources:
               - "ses:Send*"
             Resource: "*"
       Roles:
-        - !Ref WalterLambdaRole
+        - !Ref WalterBackendRole
 
   StocksTableAccessPolicy:
     Type: AWS::IAM::Policy
@@ -285,16 +298,10 @@ Resources:
               - "dynamodb:Delete*"
               - "dynamodb:Update*"
               - "dynamodb:PutItem"
-            Resource: !Join
-              - ""
-              - - "arn:aws:dynamodb:"
-                - !Ref "AWS::Region"
-                - ":"
-                - !Ref "AWS::AccountId"
-                - ":table/"
-                - !Ref StocksTable 
+            Resource: !GetAtt StocksTable.Arn
       Roles:
-        - !Ref WalterLambdaRole
+        - !Ref WalterAPIRole
+        - !Ref WalterBackendRole
 
   TemplatesBucketAccessPolicy:
     Type: AWS::IAM::Policy
@@ -306,20 +313,13 @@ Resources:
           - Effect: Allow
             Action:
               - "s3:GetObject"
-            Resource: !Join
-              - ""
-              - - "arn:aws:s3:::"
-                - !Ref TemplatesBucket
-                - "/*"
+            Resource: !Sub "${TemplatesBucket.Arn}/*"
           - Effect: Allow
             Action:
               - "s3:List*"
-            Resource: !Join
-              - ""
-              - - "arn:aws:s3:::"
-                - !Ref TemplatesBucket
+            Resource: !GetAtt TemplatesBucket.Arn
       Roles:
-        - !Ref WalterLambdaRole
+        - !Ref WalterBackendRole
 
   UsersStocksTableAccessPolicy:
     Type: AWS::IAM::Policy
@@ -338,16 +338,10 @@ Resources:
               - "dynamodb:Delete*"
               - "dynamodb:Update*"
               - "dynamodb:PutItem"
-            Resource: !Join
-              - ""
-              - - "arn:aws:dynamodb:"
-                - !Ref "AWS::Region"
-                - ":"
-                - !Ref "AWS::AccountId"
-                - ":table/"
-                - !Ref UsersStocksTable 
+            Resource: !GetAtt UsersStocksTable.Arn
       Roles:
-        - !Ref WalterLambdaRole
+        - !Ref WalterAPIRole
+        - !Ref WalterBackendRole
 
   UsersTableAccessPolicy:
     Type: AWS::IAM::Policy
@@ -366,16 +360,10 @@ Resources:
               - "dynamodb:Delete*"
               - "dynamodb:Update*"
               - "dynamodb:PutItem"
-            Resource: !Join
-              - ""
-              - - "arn:aws:dynamodb:"
-                - !Ref "AWS::Region"
-                - ":"
-                - !Ref "AWS::AccountId"
-                - ":table/"
-                - !Ref UsersTable 
+            Resource: !GetAtt UsersTable.Arn
       Roles:
-        - !Ref WalterLambdaRole
+        - !Ref WalterAPIRole
+        - !Ref WalterBackendRole
 
   ##########
   ### S3 ###
@@ -392,6 +380,11 @@ Resources:
               SSEAlgorithm: "AES256"
       VersioningConfiguration:
         Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: "DeleteOldNewsletters"
+            Status: "Enabled"
+            ExpirationInDays: 30
 
   NewslettersBucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -403,18 +396,9 @@ Resources:
           - Action: 
               - "s3:PutObject"
             Effect: Allow
-            Resource: !Join
-              - ""
-              - - "arn:aws:s3:::"
-                - !Ref NewslettersBucket
-                - "/*" 
+            Resource: !Sub "${NewslettersBucket.Arn}/*"
             Principal: 
-              AWS: !Join
-                - ""
-                - - "arn:aws:iam::"
-                  - !Ref "AWS::AccountId"
-                  - ":role/"
-                  - !Ref WalterLambdaRole
+              AWS: !GetAtt WalterBackendRole.Arn
 
   TemplatesBucket:
     Type: AWS::S3::Bucket
@@ -438,40 +422,23 @@ Resources:
           - Action: 
               - "s3:GetObject"
             Effect: Allow
-            Resource: !Join
-              - ""
-              - - "arn:aws:s3:::"
-                - !Ref TemplatesBucket
-                - "/*" 
+            Resource: !Sub "${TemplatesBucket.Arn}/*"
             Principal: 
-              AWS: !Join
-                - ""
-                - - "arn:aws:iam::"
-                  - !Ref "AWS::AccountId"
-                  - ":role/"
-                  - !Ref WalterLambdaRole
+              AWS: !GetAtt WalterBackendRole.Arn
           - Action: 
               - "s3:List*"
             Effect: Allow
-            Resource: !Join
-              - ""
-              - - "arn:aws:s3:::"
-                - !Ref TemplatesBucket
+            Resource: !GetAtt TemplatesBucket.Arn
             Principal: 
-              AWS: !Join
-                - ""
-                - - "arn:aws:iam::"
-                  - !Ref "AWS::AccountId"
-                  - ":role/"
-                  - !Ref WalterLambdaRole
+              AWS: !GetAtt WalterBackendRole.Arn
 
   ###########
   ### SQS ###
   ###########
 
-  NewsletterQueue:
+  NewslettersQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Sub "NewsletterQueue-${AppEnvironment}"
+      QueueName: !Sub "NewslettersQueue-${AppEnvironment}"
       SqsManagedSseEnabled: true
       VisibilityTimeout: 3600


### PR DESCRIPTION
This PR separates the IAM roles utilized by the different Lambda functions `WalterAPI` and `WalterBackend`.

Ensures each function only has access to the resources it requires access to but since the source code for both functions is in this repo and the clients are initialized together, `WalterAPI` needs access to SecretsManager to init the SM client.

`WalterAPI` doesn't actually need access to SM or the secret stored in SM, the Polygon API key, but to init all the clients successfully it does.