### PR TITLE
feat: Implement CreateUser, AddStock, and SendNewsletter APIs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,4 +6,4 @@ omit =
 
 [report]
 show_missing = True
-fail_under = 20
+fail_under = 40

--- a/README.md
+++ b/README.md
@@ -91,17 +91,25 @@ mkdir python \
 Use the following command to update the Walter backend code for `WalterAPI` and `WalterBackend` from the latest artifacts in S3.
 
 ```bash
-echo Updating WalterAPI source code with artifact from S3 \
-&& aws lambda update-function-code --function-name WalterAPI-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip \
+echo Updating WalterAPI CreateUser source code with artifact from S3 \
+&& aws lambda update-function-code --function-name WalterAPI-CreateUser-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip \
+&& echo Updating WalterAPI AddStock source code with artifact from S3 \
+&& aws lambda update-function-code --function-name WalterAPI-AddStock-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip \
+&& echo Updating WalterAPI SendNewsletter source code with artifact from S3 \
+&& aws lambda update-function-code --function-name WalterAPI-SendNewsletter-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip \
 && echo Updating WalterBackend source code with artifact from S3 \
 && aws lambda update-function-code --function-name WalterBackend-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip
 ```
 
-Use the following command to publish new versions for the `WalterAPI` and `WalterBackend` lambda functions. 
+Use the following command to publish new versions for the Walter Lambda functions.
 
 ```bash
-echo Publishing new WalterAPI Lambda version \
-&& aws lambda publish-version --function-name WalterAPI-dev \
+echo Publishing new WalterAPI CreateUser Lambda version \
+&& aws lambda publish-version --function-name WalterAPI-CreateUser-dev \
+echo Publishing new WalterAPI AddStock Lambda version \
+&& aws lambda publish-version --function-name WalterAPI-AddStock-dev \
+echo Publishing new WalterAPI SendNewsletter Lambda version \
+&& aws lambda publish-version --function-name WalterAPI-SendNewsletter \
 && echo Publishing new WalterBackend Lambda version \
 && aws lambda publish-version --function-name WalterBackend-dev
 ```
@@ -130,7 +138,7 @@ from S3 and the above command zips the required source code files in this reposi
 
 Use the following command to publish a message to the Newsletters Queue to invoke Walter to generate and send an email to the given user.
 
-```
+```bash
 aws sqs send-message \
   --queue-url="https://sqs.${AWS_REGION}.amazonaws.com/${AWS_ACCOUNT_ID}/NewsletterQueue-${DOMAIN}" \
   --message-body '{"email": "walteraifinancialadvisor@gmail.com", "dry_run": "false"}'

--- a/api.py
+++ b/api.py
@@ -1,5 +1,167 @@
 import json
+from enum import Enum
+
+from src.clients import walter_db, sqs
+from src.database.users.models import User
+from src.database.userstocks.models import UserStock
+from src.utils.log import Logger
+
+log = Logger(__name__).get_logger()
 
 
-def lambda_handler(event, context) -> dict:
-    return {"statusCode": 200, "body": json.dumps("WalterAPI")}
+class Status(Enum):
+    SUCCESS = "Success"
+    FAILURE = "Failure"
+
+
+class HTTPStatus(Enum):
+    OK = 200
+    BAD_REQUEST = 400
+    INTERNAL_SERVER_ERROR = 500
+
+
+########
+# APIS #
+########
+
+CREATE_USERS_API_NAME = "CreateUser"
+ADD_STOCK_API_NAME = "AddStock"
+SEND_NEWSLETTER_API_NAME = "SendNewsletter"
+
+############
+# HANDLERS #
+############
+
+
+def create_user(event, context) -> dict:
+    log.info(f"Creating user with event: {json.dumps(event, indent=4)}")
+
+    user = None
+    try:
+        body = json.loads(event["body"])
+        user = User(email=body["email"], username=body["username"])
+    except Exception as exception:
+        log.error("Client bad request to create user!", exception)
+        return {
+            "statusCode": HTTPStatus.BAD_REQUEST.value,
+            "body": json.dumps(
+                {
+                    "API": CREATE_USERS_API_NAME,
+                    "Status": Status.FAILURE.value,
+                }
+            ),
+        }
+
+    try:
+        walter_db.create_user(user)
+        return {
+            "statusCode": HTTPStatus.OK.value,
+            "body": json.dumps(
+                {
+                    "API": CREATE_USERS_API_NAME,
+                    "Status": Status.SUCCESS.value,
+                    "User": str(user),
+                }
+            ),
+        }
+    except Exception as exception:
+        log.error("Unexpected error occurred attempting to create user!", exception)
+        return {
+            "statusCode": HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            "body": json.dumps(
+                {"API": CREATE_USERS_API_NAME, "Status": Status.FAILURE.value}
+            ),
+        }
+
+
+def add_stock(event, context) -> dict:
+    log.info(
+        f"Adding stock to user portfolio with event: {json.dumps(event, indent=4)}"
+    )
+
+    stock = None
+    try:
+        body = json.loads(event["body"])
+        stock = UserStock(
+            user_email=body["email"],
+            stock_symbol=body["stock"],
+            quantity=body["quantity"],
+        )
+    except Exception as exception:
+        log.error("Client bad request to add stock to user portfolio!", exception)
+        return {
+            "statusCode": HTTPStatus.BAD_REQUEST.value,
+            "body": json.dumps(
+                {
+                    "API": ADD_STOCK_API_NAME,
+                    "Status": Status.FAILURE.value,
+                }
+            ),
+        }
+
+    try:
+        walter_db.add_stock_to_user_portfolio(stock)
+        return {
+            "statusCode": HTTPStatus.OK.value,
+            "body": json.dumps(
+                {
+                    "API": ADD_STOCK_API_NAME,
+                    "Status": Status.SUCCESS.value,
+                    "User": str(stock),
+                }
+            ),
+        }
+    except Exception as exception:
+        log.error(
+            "Unexpected error occurred attempting to add stock to user portfolio!",
+            exception,
+        )
+        return {
+            "statusCode": HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            "body": json.dumps(
+                {"API": ADD_STOCK_API_NAME, "Status": Status.FAILURE.value}
+            ),
+        }
+
+
+def send_newsletter(event, context) -> dict:
+    log.info(f"Sending newsletter to user with event: {json.dumps(event, indent=4)}")
+
+    message = None
+    try:
+        body = json.loads(event["body"])
+        message = {
+            "email": body["email"],
+        }
+    except Exception as exception:
+        log.error("Client bad request to send newsletter!", exception)
+        return {
+            "statusCode": HTTPStatus.BAD_REQUEST.value,
+            "body": json.dumps(
+                {
+                    "API": SEND_NEWSLETTER_API_NAME,
+                    "Status": Status.FAILURE.value,
+                }
+            ),
+        }
+
+    try:
+        sqs.publish_message(message)
+        return {
+            "statusCode": HTTPStatus.OK.value,
+            "body": json.dumps(
+                {
+                    "API": SEND_NEWSLETTER_API_NAME,
+                    "Status": Status.SUCCESS.value,
+                    "Newsletter": message,
+                }
+            ),
+        }
+    except Exception as exception:
+        log.error("Unexpected error occurred attempting to send newsletter!", exception)
+        return {
+            "statusCode": HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            "body": json.dumps(
+                {"API": SEND_NEWSLETTER_API_NAME, "Status": Status.FAILURE.value}
+            ),
+        }

--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -21,30 +21,117 @@ Parameters:
 
 Resources:
 
+  ###################
+  ### API GATEWAY ###
+  ###################
+
+  WalterAPIGateway:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: !Sub "WalterAPI-${AppEnvironment}"
+      Description: "API Gateway for WalterAPI"
+
+  WalterAPIUsers:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !GetAtt WalterAPIGateway.RootResourceId
+      RestApiId: !Ref WalterAPIGateway
+      PathPart: users
+
+  WalterAPICreateUserMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: POST
+      ResourceId: !Ref WalterAPIUsers
+      RestApiId: !Ref WalterAPIGateway
+      AuthorizationType: NONE
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${WalterAPICreateUser.Arn}/invocations"
+      MethodResponses:
+        - StatusCode: 200
+
+  WalterAPICreateUserPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref WalterAPICreateUser
+      Principal: apigateway.amazonaws.com
+
+  WalterAPIStocks:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !GetAtt WalterAPIGateway.RootResourceId
+      RestApiId: !Ref WalterAPIGateway
+      PathPart: stocks
+
+  WalterAPIAddStockMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: POST
+      ResourceId: !Ref WalterAPIStocks
+      RestApiId: !Ref WalterAPIGateway
+      AuthorizationType: NONE
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${WalterAPIAddStock.Arn}/invocations"
+      MethodResponses:
+        - StatusCode: 200
+
+  WalterAPIAddStockPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref WalterAPIAddStock
+      Principal: apigateway.amazonaws.com
+
+  WalterAPISendNewsletterPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref WalterAPISendNewsletter
+      Principal: apigateway.amazonaws.com
+
+  WalterAPINewsletters:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !GetAtt WalterAPIGateway.RootResourceId
+      RestApiId: !Ref WalterAPIGateway
+      PathPart: newsletters
+
+  WalterAPISendNewsletterMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: POST
+      ResourceId: !Ref WalterAPINewsletters
+      RestApiId: !Ref WalterAPIGateway
+      AuthorizationType: NONE
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${WalterAPISendNewsletter.Arn}/invocations"
+      MethodResponses:
+        - StatusCode: 200
+
   ##############
   ### LAMBDA ###
   ##############
 
-  WalterAPIAlias:
+  WalterAPICreateUserAlias:
     Type: AWS::Lambda::Alias
     Properties:
-      FunctionName: !Ref WalterAPI
+      FunctionName: !Ref WalterAPICreateUser
       FunctionVersion: $LATEST
-      Name: !Sub "WalterAPI-${AppEnvironment}"
+      Name: !Sub "WalterAPI-CreateUser-${AppEnvironment}"
 
-  WalterBackendAlias:
-    Type: AWS::Lambda::Alias
-    Properties:
-      FunctionName: !Ref WalterBackend
-      FunctionVersion: $LATEST
-      Name: !Sub "WalterBackend-${AppEnvironment}"
-
-  WalterAPI:
+  WalterAPICreateUser:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub "WalterAPI-${AppEnvironment}"
-      Description: !Sub "WalterAPI function to interact with WalterDB and WalterBackend (${AppEnvironment})"
-      Handler: api.lambda_handler
+      FunctionName: !Sub "WalterAPI-CreateUser-${AppEnvironment}"
+      Description: !Sub "WalterAPI: CreateUser - create user and add to database (${AppEnvironment})"
+      Handler: api.create_user
       Role: !GetAtt WalterAPIRole.Arn
       Code:
         S3Bucket: walter-backend-src
@@ -65,6 +152,81 @@ Resources:
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
+
+  WalterAPIAddStockAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Ref WalterAPIAddStock
+      FunctionVersion: $LATEST
+      Name: !Sub "WalterAPI-AddStock-${AppEnvironment}"
+
+  WalterAPIAddStock:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "WalterAPI-AddStock-${AppEnvironment}"
+      Description: !Sub "WalterAPI: AddStock - Add stock and number of shares to user portfolio (${AppEnvironment})"
+      Handler: api.add_stock
+      Role: !GetAtt WalterAPIRole.Arn
+      Code:
+        S3Bucket: walter-backend-src
+        S3Key: walter-backend.zip
+      Timeout: 60
+      Runtime: python3.11
+      Architectures:
+        - "arm64"
+      Layers:
+        - !Join
+          - ""
+          - - "arn:aws:lambda:"
+            - !Ref "AWS::Region"
+            - ":"
+            - !Ref "AWS::AccountId"
+            - ":layer:"
+            - "WalterAILambdaLayer:20"
+      Environment:
+        Variables:
+          DOMAIN: DEVELOPMENT
+
+  WalterAPISendNewsletterAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Ref WalterAPISendNewsletter
+      FunctionVersion: $LATEST
+      Name: !Sub "WalterAPI-SendNewsletter-${AppEnvironment}"
+
+  WalterAPISendNewsletter:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "WalterAPI-SendNewsletter-${AppEnvironment}"
+      Description: !Sub "WalterAPI: SendNewsletter - generate and send a newsletter to the given user (${AppEnvironment})"
+      Handler: api.send_newsletter
+      Role: !GetAtt WalterAPIRole.Arn
+      Code:
+        S3Bucket: walter-backend-src
+        S3Key: walter-backend.zip
+      Timeout: 60
+      Runtime: python3.11
+      Architectures:
+        - "arm64"
+      Layers:
+        - !Join
+          - ""
+          - - "arn:aws:lambda:"
+            - !Ref "AWS::Region"
+            - ":"
+            - !Ref "AWS::AccountId"
+            - ":layer:"
+            - "WalterAILambdaLayer:20"
+      Environment:
+        Variables:
+          DOMAIN: DEVELOPMENT
+
+  WalterBackendAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Ref WalterBackend
+      FunctionVersion: $LATEST
+      Name: !Sub "WalterBackend-${AppEnvironment}"
 
   WalterBackend:
       Type: AWS::Lambda::Function
@@ -242,8 +404,10 @@ Resources:
               - "sqs:ReceiveMessage"
               - "sqs:DeleteMessage"
               - "sqs:GetQueueAttributes"
+              - "sqs:SendMessage"
             Resource: !GetAtt NewslettersQueue.Arn
       Roles:
+        - !Ref WalterAPIRole
         - !Ref WalterBackendRole
 
   SecretsManagerAccessPolicy:
@@ -442,3 +606,15 @@ Resources:
       QueueName: !Sub "NewslettersQueue-${AppEnvironment}"
       SqsManagedSseEnabled: true
       VisibilityTimeout: 3600
+
+###############
+### OUTPUTS ###
+###############
+
+Outputs:
+  WalterAPICreateUserEndpoint:
+    Value: !Sub "https://${WalterAPIGateway}.execute-api.${AWS::Region}.amazonaws.com/${AppEnvironment}/users"
+  WalterAPIAddStockEndpoint:
+    Value: !Sub "https://${WalterAPIGateway}.execute-api.${AWS::Region}.amazonaws.com/${AppEnvironment}/stocks"
+  WalterAPISendNewsletterEndpoint:
+    Value: !Sub "https://${WalterAPIGateway}.execute-api.${AWS::Region}.amazonaws.com/${AppEnvironment}/newsletters"

--- a/src/aws/sqs/client.py
+++ b/src/aws/sqs/client.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import dataclass
 
 from botocore.exceptions import ClientError
@@ -15,29 +16,43 @@ ACCOUNT_ID = "010526272437"
 class WalterSQSClient:
 
     QUEUE_URL_FORMAT = (
-        "https://sqs.{region}.amazonaws.com/{account_id}/NewsletterQueue-{domain}"
+        "https://sqs.{region}.amazonaws.com/{account_id}/NewslettersQueue-{domain}"
     )
 
     client: SQSClient
     domain: Domain
 
+    queue_url: str = None
+
     def __post_init__(self) -> None:
+        self.queue_url = self._get_queue_url()
         log.debug(
-            f"Creating Walter SQS client in region '{self.client.meta.region_name}''"
+            f"Creating Walter SQS client in region '{self.client.meta.region_name}' with queue URL '{self.queue_url}'"
         )
 
-    def delete_event(self, receipt_handle: str) -> None:
-        queue_url = self._get_queue_url()
-        log.debug(
-            f"Deleting message with the following receipt handle from queue '{queue_url}': {receipt_handle}"
-        )
+    def publish_message(self, message: dict) -> None:
+        log.debug(f"Publishing message to queue '{self.queue_url}'")
         try:
-            self.client.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
+            self.client.send_message(QueueUrl=self.queue_url, MessageBody=json.dumps(message))
         except ClientError as error:
             log.error(
-                f"Unexpected error occurred deleting message from queue '{queue_url}'\n"
+                f"Unexpected error occurred publishing message to queue '{self.queue_url}'\n"
                 f"Error: {error.response['Error']['Message']}"
             )
+            raise error
+
+    def delete_event(self, receipt_handle: str) -> None:
+        log.debug(
+            f"Deleting message with the following receipt handle from queue '{self.queue_url}': {receipt_handle}"
+        )
+        try:
+            self.client.delete_message(QueueUrl=self.queue_url, ReceiptHandle=receipt_handle)
+        except ClientError as error:
+            log.error(
+                f"Unexpected error occurred deleting message from queue '{self.queue_url}'\n"
+                f"Error: {error.response['Error']['Message']}"
+            )
+            raise error
 
     def _get_queue_url(self) -> str:
         return WalterSQSClient.QUEUE_URL_FORMAT.format(

--- a/src/database/client.py
+++ b/src/database/client.py
@@ -43,3 +43,6 @@ class WalterDB:
     def get_stocks_for_user(self, user: User) -> Dict[str, UserStock]:
         stocks = self.users_stocks_table.get_stocks_for_user(user)
         return {stock.stock_symbol: stock for stock in stocks}
+
+    def add_stock_to_user_portfolio(self, stock: UserStock) -> None:
+        self.users_stocks_table.add_stocks_to_user_portfolio(stock)

--- a/src/database/users/models.py
+++ b/src/database/users/models.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import dataclass
 
 
@@ -13,3 +14,12 @@ class User:
             },
             "username": {"S": self.username},
         }
+
+    def __str__(self) -> str:
+        return json.dumps(
+            {
+                "email": self.email,
+                "username": self.username,
+            },
+            indent=4
+        )

--- a/src/database/userstocks/models.py
+++ b/src/database/userstocks/models.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import dataclass
 
 
@@ -23,3 +24,10 @@ class UserStock:
             "stock_symbol": {"S": self.stock_symbol},
             "quantity": {"S": str(self.quantity)},
         }
+
+    def __str__(self) -> str:
+        return json.dumps({
+            "email": self.user_email,
+            "stock": self.stock_symbol,
+            "quantity": self.quantity,
+        })

--- a/src/database/userstocks/table.py
+++ b/src/database/userstocks/table.py
@@ -35,6 +35,20 @@ class UsersStocksTable:
         self.table = UsersStocksTable._get_table_name(self.domain)
         log.debug(f"Creating UsersStocks table DDB client for table '{self.table}'")
 
+    def add_stocks_to_user_portfolio(self, stock: UserStock) -> None:
+        """
+        Add stock to user portfolio.
+
+        Args:
+            stock: The stock and number of shares owned by the user.
+
+        Returns:
+            None.
+        """
+        log.info(f"Adding stock to user portfolio:\n{stock}")
+        self.ddb.put_item(self.table, stock.to_ddb_item())
+        log.info("Added stock to user portfolio!")
+
     def get_stocks_for_user(self, user: User) -> List[UserStock]:
         """
         Get the stocks owned by a user and the number of shares owned.


### PR DESCRIPTION
This PR implements the following APIs as `WalterAPI` Lambdas (each API is served by its own Lambda with an API Gateway proxy):

* `CreateUser` - Add a user to `WalterDB`
* `AddStock` - Add a stock and number of shares to a user's portfolio to `WalterDB`
* `SendNewsletter` - Generate and send a newsletter to user (publishes newsletter request to SQS for `WalterBackend` to consume)