### PR TITLE
feat: Add auth support for users

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,6 +19,7 @@ mypy-boto3-lambda = "*"
 jinja2 = "*"
 pyyaml = "*"
 mypy-boto3-sqs = "*"
+bcrypt = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "31e004a70b1106b727498f333540678838db052d0eb062f48b3520ee68082fe5"
+            "sha256": "12b3cbcb95a513c13d8d3e867abaf70b59d033b0a13a3822dff12a2220ca63fb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,22 +16,56 @@
         ]
     },
     "default": {
+        "bcrypt": {
+            "hashes": [
+                "sha256:096a15d26ed6ce37a14c1ac1e48119660f21b24cba457f160a4b830f3fe6b5cb",
+                "sha256:0da52759f7f30e83f1e30a888d9163a81353ef224d82dc58eb5bb52efcabc399",
+                "sha256:1bb429fedbe0249465cdd85a58e8376f31bb315e484f16e68ca4c786dcc04291",
+                "sha256:1d84cf6d877918620b687b8fd1bf7781d11e8a0998f576c7aa939776b512b98d",
+                "sha256:1ee38e858bf5d0287c39b7a1fc59eec64bbf880c7d504d3a06a96c16e14058e7",
+                "sha256:1ff39b78a52cf03fdf902635e4c81e544714861ba3f0efc56558979dd4f09170",
+                "sha256:27fe0f57bb5573104b5a6de5e4153c60814c711b29364c10a75a54bb6d7ff48d",
+                "sha256:3413bd60460f76097ee2e0a493ccebe4a7601918219c02f503984f0a7ee0aebe",
+                "sha256:3698393a1b1f1fd5714524193849d0c6d524d33523acca37cd28f02899285060",
+                "sha256:373db9abe198e8e2c70d12b479464e0d5092cc122b20ec504097b5f2297ed184",
+                "sha256:39e1d30c7233cfc54f5c3f2c825156fe044efdd3e0b9d309512cc514a263ec2a",
+                "sha256:3bbbfb2734f0e4f37c5136130405332640a1e46e6b23e000eeff2ba8d005da68",
+                "sha256:3d3a6d28cb2305b43feac298774b997e372e56c7c7afd90a12b3dc49b189151c",
+                "sha256:5a1e8aa9b28ae28020a3ac4b053117fb51c57a010b9f969603ed885f23841458",
+                "sha256:61ed14326ee023917ecd093ee6ef422a72f3aec6f07e21ea5f10622b735538a9",
+                "sha256:655ea221910bcac76ea08aaa76df427ef8625f92e55a8ee44fbf7753dbabb328",
+                "sha256:762a2c5fb35f89606a9fde5e51392dad0cd1ab7ae64149a8b935fe8d79dd5ed7",
+                "sha256:77800b7147c9dc905db1cba26abe31e504d8247ac73580b4aa179f98e6608f34",
+                "sha256:8ac68872c82f1add6a20bd489870c71b00ebacd2e9134a8aa3f98a0052ab4b0e",
+                "sha256:8d7bb9c42801035e61c109c345a28ed7e84426ae4865511eb82e913df18f58c2",
+                "sha256:8f6ede91359e5df88d1f5c1ef47428a4420136f3ce97763e31b86dd8280fbdf5",
+                "sha256:9c1c4ad86351339c5f320ca372dfba6cb6beb25e8efc659bedd918d921956bae",
+                "sha256:c02d944ca89d9b1922ceb8a46460dd17df1ba37ab66feac4870f6862a1533c00",
+                "sha256:c52aac18ea1f4a4f65963ea4f9530c306b56ccd0c6f8c8da0c06976e34a6e841",
+                "sha256:cb2a8ec2bc07d3553ccebf0746bbf3d19426d1c6d1adbd4fa48925f66af7b9e8",
+                "sha256:cf69eaf5185fd58f268f805b505ce31f9b9fc2d64b376642164e9244540c1221",
+                "sha256:f4f4acf526fcd1c34e7ce851147deedd4e26e6402369304220250598b26448db"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==4.2.0"
+        },
         "boto3": {
             "hashes": [
-                "sha256:385ca77bf8ea4ab2d97f6e2435bdb29f77d9301e2f7ac796c2f465753c2adf3c",
-                "sha256:470d981583885859fed2fd1c185eeb01cc03e60272d499bafe41b12625b158c8"
+                "sha256:5970b62c1ec8177501e02520f0d41839ca5fc549b30bac4e8c0c0882ae776217",
+                "sha256:670f811c65e3c5fe4ed8c8d69be0b44b1d649e992c0fc16de43816d1188f88f1"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.35.37"
+            "version": "==1.35.39"
         },
         "botocore": {
             "hashes": [
-                "sha256:64f965d4ba7adb8d79ce044c3aef7356e05dd74753cf7e9115b80f477845d920",
-                "sha256:b2b4d29bafd95b698344f2f0577bb67064adbf1735d8a0e3c7473daa59c23ba6"
+                "sha256:781c547eb6a79c0e4b0bedd87b81fbfed957816b4841d33e20c8f1989c7c19ce",
+                "sha256:cb7f851933b5ccc2fba4f0a8b846252410aa0efac5bfbe93b82d10801f5f8e90"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.35.37"
+            "version": "==1.35.39"
         },
         "certifi": {
             "hashes": [
@@ -452,20 +486,20 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:385ca77bf8ea4ab2d97f6e2435bdb29f77d9301e2f7ac796c2f465753c2adf3c",
-                "sha256:470d981583885859fed2fd1c185eeb01cc03e60272d499bafe41b12625b158c8"
+                "sha256:5970b62c1ec8177501e02520f0d41839ca5fc549b30bac4e8c0c0882ae776217",
+                "sha256:670f811c65e3c5fe4ed8c8d69be0b44b1d649e992c0fc16de43816d1188f88f1"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.35.37"
+            "version": "==1.35.39"
         },
         "botocore": {
             "hashes": [
-                "sha256:64f965d4ba7adb8d79ce044c3aef7356e05dd74753cf7e9115b80f477845d920",
-                "sha256:b2b4d29bafd95b698344f2f0577bb67064adbf1735d8a0e3c7473daa59c23ba6"
+                "sha256:781c547eb6a79c0e4b0bedd87b81fbfed957816b4841d33e20c8f1989c7c19ce",
+                "sha256:cb7f851933b5ccc2fba4f0a8b846252410aa0efac5bfbe93b82d10801f5f8e90"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.35.37"
+            "version": "==1.35.39"
         },
         "certifi": {
             "hashes": [
@@ -689,72 +723,72 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:078a87519057dacb5d77e333f740708ec2a8f768655f1db07f8dfd28d7a005f0",
-                "sha256:087932079c065d7b8ebadd3a0160656c55954144af6439886c8bcf78bbbcde7f",
-                "sha256:0bbae11c138585c89fb4e991faefb174a80112e1a7557d507aaa07675c62e66b",
-                "sha256:0ff2ef83d6d0b527b5c9dad73819b24a2f76fdddcfd6c4e7a4d7e73ecb0656b4",
-                "sha256:12179eb0575b8900912711688e45474f04ab3934aaa7b624dea7b3c511ecc90f",
-                "sha256:1e5e92e3e84a8718d2de36cd8387459cba9a4508337b8c5f450ce42b87a9e760",
-                "sha256:2186369a654a15628e9c1c9921409a6b3eda833e4b91f3ca2a7d9f77abb4987c",
-                "sha256:21c0ea0d4db8a36b275cb6fb2437a3715697a4ba3cb7b918d3525cc75f726304",
-                "sha256:24500f4b0e03aab60ce575c85365beab64b44d4db837021e08339f61d1fbfe52",
-                "sha256:2b636a301e53964550e2f3094484fa5a96e699db318d65398cfba438c5c92171",
-                "sha256:343056c5e0737487a5291f5691f4dfeb25b3e3c8699b4d36b92bb0e586219d14",
-                "sha256:35a51598f29b2a19e26d0908bd196f771a9b1c5d9a07bf20be0adf28f1ad4f77",
-                "sha256:39d3b964abfe1519b9d313ab28abf1d02faea26cd14b27f5283849bf59479ff5",
-                "sha256:3ec528ae69f0a139690fad6deac8a7d33629fa61ccce693fdd07ddf7e9931fba",
-                "sha256:47ccb6e99a3031ffbbd6e7cc041e70770b4fe405370c66a54dbf26a500ded80b",
-                "sha256:4eea60c79d36a8f39475b1af887663bc3ae4f31289cd216f514ce18d5938df40",
-                "sha256:536f77f2bf5797983652d1d55f1a7272a29afcc89e3ae51caa99b2db4e89d658",
-                "sha256:5ed69befa9a9fc796fe015a7040c9398722d6b97df73a6b608e9e275fa0932b0",
-                "sha256:62ab4231c01e156ece1b3a187c87173f31cbeee83a5e1f6dff17f288dca93345",
-                "sha256:667952739daafe9616db19fbedbdb87917eee253ac4f31d70c7587f7ab531b4e",
-                "sha256:69f251804e052fc46d29d0e7348cdc5fcbfc4861dc4a1ebedef7e78d241ad39e",
-                "sha256:6c2ba1e0c24d8fae8f2cf0aeb2fc0a2a7f69b6d20bd8d3749fd6b36ecef5edf0",
-                "sha256:6e85830eed5b5263ffa0c62428e43cb844296f3b4461f09e4bdb0d44ec190bc2",
-                "sha256:7571e8bbecc6ac066256f9de40365ff833553e2e0c0c004f4482facb131820ef",
-                "sha256:7781f4f70c9b0b39e1b129b10c7d43a4e0c91f90c60435e6da8288efc2b73438",
-                "sha256:7926d8d034e06b479797c199747dd774d5e86179f2ce44294423327a88d66ca7",
-                "sha256:7b80fbb0da3aebde102a37ef0138aeedff45997e22f8962e5f16ae1742852676",
-                "sha256:7fca4a92c8a7a73dee6946471bce6d1443d94155694b893b79e19ca2a540d86e",
-                "sha256:84c4315577f7cd511d6250ffd0f695c825efe729f4205c0340f7004eda51191f",
-                "sha256:8d9c5d13927d77af4fbe453953810db766f75401e764727e73a6ee4f82527b3e",
-                "sha256:9681516288e3dcf0aa7c26231178cc0be6cac9705cac06709f2353c5b406cfea",
-                "sha256:97df87e1a20deb75ac7d920c812e9326096aa00a9a4b6d07679b4f1f14b06c90",
-                "sha256:9bcd51eeca35a80e76dc5794a9dd7cb04b97f0e8af620d54711793bfc1fbba4b",
-                "sha256:9c6b0c1cafd96213a0327cf680acb39f70e452caf8e9a25aeb05316db9c07f89",
-                "sha256:a5f81e68aa62bc0cfca04f7b19eaa8f9c826b53fc82ab9e2121976dc74f131f3",
-                "sha256:a663b180b6669c400b4630a24cc776f23a992d38ce7ae72ede2a397ce6b0f170",
-                "sha256:a7b2e437fbd8fae5bc7716b9c7ff97aecc95f0b4d56e4ca08b3c8d8adcaadb84",
-                "sha256:a867d26f06bcd047ef716175b2696b315cb7571ccb951006d61ca80bbc356e9e",
-                "sha256:aa68a6cdbe1bc6793a9dbfc38302c11599bbe1837392ae9b1d238b9ef3dafcf1",
-                "sha256:ab31fdd643f162c467cfe6a86e9cb5f1965b632e5e65c072d90854ff486d02cf",
-                "sha256:ad4ef1c56b47b6b9024b939d503ab487231df1f722065a48f4fc61832130b90e",
-                "sha256:b92f9ca04b3e719d69b02dc4a69debb795af84cb7afd09c5eb5d54b4a1ae2191",
-                "sha256:bb21bac7783c1bf6f4bbe68b1e0ff0d20e7e7732cfb7995bc8d96e23aa90fc7b",
-                "sha256:bf4eeecc9e10f5403ec06138978235af79c9a79af494eb6b1d60a50b49ed2869",
-                "sha256:bfde025e2793a22efe8c21f807d276bd1d6a4bcc5ba6f19dbdfc4e7a12160909",
-                "sha256:c37faddc8acd826cfc5e2392531aba734b229741d3daec7f4c777a8f0d4993e5",
-                "sha256:c71965d1ced48bf97aab79fad56df82c566b4c498ffc09c2094605727c4b7e36",
-                "sha256:c9192925acc33e146864b8cf037e2ed32a91fdf7644ae875f5d46cd2ef086a5f",
-                "sha256:c9df1950fb92d49970cce38100d7e7293c84ed3606eaa16ea0b6bc27175bb667",
-                "sha256:cdfcf2e914e2ba653101157458afd0ad92a16731eeba9a611b5cbb3e7124e74b",
-                "sha256:d03a060ac1a08e10589c27d509bbdb35b65f2d7f3f8d81cf2fa199877c7bc58a",
-                "sha256:d20c3d1f31f14d6962a4e2f549c21d31e670b90f777ef4171be540fb7fb70f02",
-                "sha256:e4ee15b267d2dad3e8759ca441ad450c334f3733304c55210c2a44516e8d5530",
-                "sha256:e8ea055b3ea046c0f66217af65bc193bbbeca1c8661dc5fd42698db5795d2627",
-                "sha256:ebabdf1c76593a09ee18c1a06cd3022919861365219ea3aca0247ededf6facd6",
-                "sha256:ebc94fadbd4a3f4215993326a6a00e47d79889391f5659bf310f55fe5d9f581c",
-                "sha256:ed5ac02126f74d190fa2cc14a9eb2a5d9837d5863920fa472b02eb1595cdc925",
-                "sha256:f01e53575f27097d75d42de33b1b289c74b16891ce576d767ad8c48d17aeb5e0",
-                "sha256:f361296ca7054f0936b02525646b2731b32c8074ba6defab524b79b2b7eeac72",
-                "sha256:f9035695dadfb397bee9eeaf1dc7fbeda483bf7664a7397a629846800ce6e276",
-                "sha256:fcad7d5d2bbfeae1026b395036a8aa5abf67e8038ae7e6a25c7d0f88b10a8e6a",
-                "sha256:ff797320dcbff57caa6b2301c3913784a010e13b1f6cf4ab3f563f3c5e7919db"
+                "sha256:04f2189716e85ec9192df307f7c255f90e78b6e9863a03223c3b998d24a3c6c6",
+                "sha256:0c6c0f4d53ef603397fc894a895b960ecd7d44c727df42a8d500031716d4e8d2",
+                "sha256:0ca37993206402c6c35dc717f90d4c8f53568a8b80f0bf1a1b2b334f4d488fba",
+                "sha256:12f9515d875859faedb4144fd38694a761cd2a61ef9603bf887b13956d0bbfbb",
+                "sha256:1990b1f4e2c402beb317840030bb9f1b6a363f86e14e21b4212e618acdfce7f6",
+                "sha256:2341a78ae3a5ed454d524206a3fcb3cec408c2a0c7c2752cd78b606a2ff15af4",
+                "sha256:23bb63ae3f4c645d2d82fa22697364b0046fbafb6261b258a58587441c5f7bd0",
+                "sha256:27bd5f18d8f2879e45724b0ce74f61811639a846ff0e5c0395b7818fae87aec6",
+                "sha256:2dc7d6b380ca76f5e817ac9eef0c3686e7834c8346bef30b041a4ad286449990",
+                "sha256:331b200ad03dbaa44151d74daeb7da2cf382db424ab923574f6ecca7d3b30de3",
+                "sha256:365defc257c687ce3e7d275f39738dcd230777424117a6c76043459db131dd43",
+                "sha256:37be7b5ea3ff5b7c4a9db16074dc94523b5f10dd1f3b362a827af66a55198175",
+                "sha256:3c2e6fa98032fec8282f6b27e3f3986c6e05702828380618776ad794e938f53a",
+                "sha256:40e8b1983080439d4802d80b951f4a93d991ef3261f69e81095a66f86cf3c3c6",
+                "sha256:43517e1f6b19f610a93d8227e47790722c8bf7422e46b365e0469fc3d3563d97",
+                "sha256:43b32a06c47539fe275106b376658638b418c7cfdfff0e0259fbf877e845f14b",
+                "sha256:43d6a66e33b1455b98fc7312b124296dad97a2e191c80320587234a77b1b736e",
+                "sha256:4c59d6a4a4633fad297f943c03d0d2569867bd5372eb5684befdff8df8522e39",
+                "sha256:52ac29cc72ee7e25ace7807249638f94c9b6a862c56b1df015d2b2e388e51dbd",
+                "sha256:54356a76b67cf8a3085818026bb556545ebb8353951923b88292556dfa9f812d",
+                "sha256:583049c63106c0555e3ae3931edab5669668bbef84c15861421b94e121878d3f",
+                "sha256:6d99198203f0b9cb0b5d1c0393859555bc26b548223a769baf7e321a627ed4fc",
+                "sha256:6da42bbcec130b188169107ecb6ee7bd7b4c849d24c9370a0c884cf728d8e976",
+                "sha256:6e484e479860e00da1f005cd19d1c5d4a813324e5951319ac3f3eefb497cc549",
+                "sha256:70a6756ce66cd6fe8486c775b30889f0dc4cb20c157aa8c35b45fd7868255c5c",
+                "sha256:70d24936ca6c15a3bbc91ee9c7fc661132c6f4c9d42a23b31b6686c05073bde5",
+                "sha256:71967c35828c9ff94e8c7d405469a1fb68257f686bca7c1ed85ed34e7c2529c4",
+                "sha256:79644f68a6ff23b251cae1c82b01a0b51bc40c8468ca9585c6c4b1aeee570e0b",
+                "sha256:87cd2e29067ea397a47e352efb13f976eb1b03e18c999270bb50589323294c6e",
+                "sha256:8d4c6ea0f498c7c79111033a290d060c517853a7bcb2f46516f591dab628ddd3",
+                "sha256:9134032f5aa445ae591c2ba6991d10136a1f533b1d2fa8f8c21126468c5025c6",
+                "sha256:921fbe13492caf6a69528f09d5d7c7d518c8d0e7b9f6701b7719715f29a71e6e",
+                "sha256:99670790f21a96665a35849990b1df447993880bb6463a0a1d757897f30da929",
+                "sha256:9975442f2e7a5cfcf87299c26b5a45266ab0696348420049b9b94b2ad3d40234",
+                "sha256:99ded130555c021d99729fabd4ddb91a6f4cc0707df4b1daf912c7850c373b13",
+                "sha256:a3328c3e64ea4ab12b85999eb0779e6139295bbf5485f69d42cf794309e3d007",
+                "sha256:a4fb91d5f72b7e06a14ff4ae5be625a81cd7e5f869d7a54578fc271d08d58ae3",
+                "sha256:aa23ce39661a3e90eea5f99ec59b763b7d655c2cada10729ed920a38bfc2b167",
+                "sha256:aac7501ae73d4a02f4b7ac8fcb9dc55342ca98ffb9ed9f2dfb8a25d53eda0e4d",
+                "sha256:ab84a8b698ad5a6c365b08061920138e7a7dd9a04b6feb09ba1bfae68346ce6d",
+                "sha256:b4adeb878a374126f1e5cf03b87f66279f479e01af0e9a654cf6d1509af46c40",
+                "sha256:b9853509b4bf57ba7b1f99b9d866c422c9c5248799ab20e652bbb8a184a38181",
+                "sha256:bb7d5fe92bd0dc235f63ebe9f8c6e0884f7360f88f3411bfed1350c872ef2054",
+                "sha256:bca4c8abc50d38f9773c1ec80d43f3768df2e8576807d1656016b9d3eeaa96fd",
+                "sha256:c222958f59b0ae091f4535851cbb24eb57fc0baea07ba675af718fb5302dddb2",
+                "sha256:c30e42ea11badb147f0d2e387115b15e2bd8205a5ad70d6ad79cf37f6ac08c91",
+                "sha256:c3a79f56dee9136084cf84a6c7c4341427ef36e05ae6415bf7d787c96ff5eaa3",
+                "sha256:c51ef82302386d686feea1c44dbeef744585da16fcf97deea2a8d6c1556f519b",
+                "sha256:c77326300b839c44c3e5a8fe26c15b7e87b2f32dfd2fc9fee1d13604347c9b38",
+                "sha256:d33a785ea8354c480515e781554d3be582a86297e41ccbea627a5c632647f2cd",
+                "sha256:d546cfa78844b8b9c1c0533de1851569a13f87449897bbc95d698d1d3cb2a30f",
+                "sha256:da29ceabe3025a1e5a5aeeb331c5b1af686daab4ff0fb4f83df18b1180ea83e2",
+                "sha256:df8c05a0f574d480947cba11b947dc41b1265d721c3777881da2fb8d3a1ddfba",
+                "sha256:e266af4da2c1a4cbc6135a570c64577fd3e6eb204607eaff99d8e9b710003c6f",
+                "sha256:e279f3db904e3b55f520f11f983cc8dc8a4ce9b65f11692d4718ed021ec58b83",
+                "sha256:ea52bd218d4ba260399a8ae4bb6b577d82adfc4518b93566ce1fddd4a49d1dce",
+                "sha256:ebec65f5068e7df2d49466aab9128510c4867e532e07cb6960075b27658dca38",
+                "sha256:ec1e3b40b82236d100d259854840555469fad4db64f669ab817279eb95cd535c",
+                "sha256:ee77c7bef0724165e795b6b7bf9c4c22a9b8468a6bdb9c6b4281293c6b22a90f",
+                "sha256:f263b18692f8ed52c8de7f40a0751e79015983dbd77b16906e5b310a39d3ca21",
+                "sha256:f7b26757b22faf88fcf232f5f0e62f6e0fd9e22a8a5d0d5016888cdfe1f6c1c4",
+                "sha256:f7ddb920106bbbbcaf2a274d56f46956bf56ecbde210d88061824a95bdd94e92"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==7.6.2"
+            "version": "==7.6.3"
         },
         "cryptography": {
             "hashes": [
@@ -943,11 +977,11 @@
                 "dynamodb2"
             ],
             "hashes": [
-                "sha256:4ce1f34830307f7b3d553d77a7ef26066ab3b70006203d4226b048c9d11a3be4",
-                "sha256:f4afb176a964cd7a70da9bc5e053d43109614ce3cab26044bcbb53610435dff4"
+                "sha256:165a291ac0b983f53a09f67f9841f72214c5a1b0c56392d88f7035a6a8718fca",
+                "sha256:6b56b7bb5675d60e79890c9867e446f29d7a5be02051238b8df079f649270130"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==5.0.16"
+            "version": "==5.0.17"
         },
         "mypy-extensions": {
             "hashes": [

--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -148,7 +148,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:20"
+            - "WalterAILambdaLayer:21"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -182,7 +182,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:20"
+            - "WalterAILambdaLayer:21"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -216,7 +216,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:20"
+            - "WalterAILambdaLayer:21"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -250,7 +250,7 @@ Resources:
               - ":"
               - !Ref "AWS::AccountId"
               - ":layer:"
-              - "WalterAILambdaLayer:20"
+              - "WalterAILambdaLayer:21"
         Environment:
           Variables:
             DOMAIN: DEVELOPMENT

--- a/src/database/client.py
+++ b/src/database/client.py
@@ -8,6 +8,7 @@ from src.database.users.table import UsersTable
 from src.database.userstocks.models import UserStock
 from src.database.userstocks.table import UsersStocksTable
 from src.environment import Domain
+from src.utils.auth import hash_password
 from src.utils.log import Logger
 
 log = Logger(__name__).get_logger()
@@ -28,7 +29,15 @@ class WalterDB:
         self.stocks_table = StocksTable(self.ddb, self.domain)
         self.users_stocks_table = UsersStocksTable(self.ddb, self.domain)
 
-    def create_user(self, user: User) -> None:
+    def create_user(self, email: str, username: str, password: str) -> None:
+        # generate salt and hash the given password to store in users table
+        salt, password_hash = hash_password(password)
+        user = User(
+            email=email,
+            username=username,
+            password_hash=password_hash.decode(),
+            salt=salt.decode(),
+        )
         self.users_table.create_user(user)
 
     def get_user(self, email: str) -> User:

--- a/src/database/users/models.py
+++ b/src/database/users/models.py
@@ -6,6 +6,22 @@ from dataclasses import dataclass
 class User:
     email: str
     username: str
+    password_hash: str
+    salt: str
+
+    def __dict__(self) -> dict:
+        return {
+            "email": self.email,
+            "username": self.username,
+            "password_hash": self.password_hash,
+            "salt": self.salt,
+        }
+
+    def __str__(self) -> str:
+        return json.dumps(
+            self.__dict__(),
+            indent=4,
+        )
 
     def to_ddb_item(self) -> dict:
         return {
@@ -13,13 +29,6 @@ class User:
                 "S": self.email,
             },
             "username": {"S": self.username},
+            "password_hash": {"S": self.password_hash},
+            "salt": {"S": self.salt},
         }
-
-    def __str__(self) -> str:
-        return json.dumps(
-            {
-                "email": self.email,
-                "username": self.username,
-            },
-            indent=4,
-        )

--- a/src/database/users/table.py
+++ b/src/database/users/table.py
@@ -64,4 +64,9 @@ class UsersTable:
 
     @staticmethod
     def _get_user_from_ddb_item(item: dict) -> User:
-        return User(email=item["email"]["S"], username=item["username"]["S"])
+        return User(
+            email=item["email"]["S"],
+            username=item["username"]["S"],
+            password_hash=item["password_hash"]["S"],
+            salt=item["salt"]["S"],
+        )

--- a/src/utils/auth.py
+++ b/src/utils/auth.py
@@ -1,0 +1,38 @@
+from typing import Tuple
+
+import bcrypt
+
+
+def hash_password(password: str) -> Tuple[bytes, bytes]:
+    """
+    Hash the given password.
+
+    This method just uses bcrypt: https://github.com/pyca/bcrypt
+
+    Args:
+        password: The password in plaintext before salting and hashing.s
+
+    Returns:
+        salt, password_hash
+    """
+    if isinstance(password, str) is False:
+        raise TypeError("Password must be a string!")
+    salt = bcrypt.gensalt()
+    password_hash = bcrypt.hashpw(password.encode(), salt)
+    return salt, password_hash
+
+
+def check_password(password: str, password_hash: str) -> bool:
+    """
+    Checks if a given password matches the given password hash.
+
+    Args:
+        password: The password in plaintext to check.
+        password_hash: The hashed password to check against.
+
+    Returns:
+        boolean: True if the given password matches the given password hash, False otherwise.
+    """
+    if isinstance(password, str) is False or isinstance(password_hash, str) is False:
+        raise TypeError("Password and password hash must both be strings!")
+    return bcrypt.checkpw(password.encode(), password_hash.encode())

--- a/tst/conftest.py
+++ b/tst/conftest.py
@@ -75,7 +75,10 @@ def ddb_client() -> DynamoDBClient:
                 mock_ddb.put_item(
                     TableName=USERS_TABLE_NAME,
                     Item=User(
-                        email=json_user["email"], username=json_user["username"]
+                        email=json_user["email"],
+                        username=json_user["username"],
+                        password_hash=json_user["password_hash"],
+                        salt=json_user["salt"],
                     ).to_ddb_item(),
                 )
 

--- a/tst/database/data/users.jsonl
+++ b/tst/database/data/users.jsonl
@@ -1,2 +1,2 @@
-{"email":  "walter@gmail.com", "username":  "walter"}
-{"email":  "walrus@gmail.com", "username":  "walrus"}
+{"email":  "walter@gmail.com", "username":  "walter", "password_hash": "walter", "salt": "walter"}
+{"email":  "walrus@gmail.com", "username":  "walrus", "password_hash": "walrus", "salt": "walrus"}

--- a/tst/database/test_walter_db.py
+++ b/tst/database/test_walter_db.py
@@ -6,8 +6,18 @@ from src.database.users.models import User
 from src.database.userstocks.models import UserStock
 from src.environment import Domain
 
-WALTER = User(email="walter@gmail.com", username="walter")
-WALRUS = User(email="walrus@gmail.com", username="walrus")
+WALTER = User(
+    email="walter@gmail.com",
+    username="walter",
+    password_hash="walter",
+    salt="walter",
+)
+WALRUS = User(
+    email="walrus@gmail.com",
+    username="walrus",
+    password_hash="walrus",
+    salt="walrus",
+)
 
 WALTER_STOCKS = [
     UserStock(user_email=WALTER.email, stock_symbol="AAPL", quantity=1.0),

--- a/tst/newsletters/test_newsletters_queue.py
+++ b/tst/newsletters/test_newsletters_queue.py
@@ -8,7 +8,9 @@ from src.database.users.models import User
 from src.environment import Domain
 from src.newsletters.queue import NewslettersQueue, NewsletterRequest
 
-WALTER = User(email="walter@gmail.com", username="walter")
+WALTER = User(
+    email="walter@gmail.com", username="walter", password_hash="password", salt="salt"
+)
 
 ADD_NEWSLETTER_REQUEST = NewsletterRequest(
     email=WALTER.email,

--- a/tst/stocks/test_walter_stocks_api.py
+++ b/tst/stocks/test_walter_stocks_api.py
@@ -15,7 +15,9 @@ from src.stocks.polygon.client import PolygonClient
 from src.stocks.polygon.models import StockPrices, StockPrice, StockNews
 from tst.conftest import SECRETS_MANAGER_POLIGON_API_KEY_VALUE
 
-WALTER = User(email="walter@gmail.com", username="walter")
+WALTER = User(
+    email="walter@gmail.com", username="walter", password_hash="password", salt="salt"
+)
 
 START_DATE = dt(year=2024, month=10, day=1, hour=0, minute=0, second=0, microsecond=0)
 END_DATE = dt(year=2024, month=10, day=1, hour=2, minute=0, second=0, microsecond=0)

--- a/tst/utils/test_auth.py
+++ b/tst/utils/test_auth.py
@@ -1,0 +1,9 @@
+from src.utils.auth import hash_password, check_password
+
+
+def test_check_password() -> None:
+    incorrect_password = "incorrect"
+    password = "password"
+    salt, hashed_password = hash_password(password)
+    assert check_password(password, hashed_password.decode()) is True
+    assert check_password(incorrect_password, hashed_password.decode()) is False


### PR DESCRIPTION
This PR adds super simple auth support for users.

Adds util methods to generate salt, hash password, check password hashes using `bcrypt`: https://github.com/pyca/bcrypt

Need to work on JWT next to authenticate users and then allow them to call authenticated APIs to send a newsletter, add stocks to their portfolio, etc. 