### PR TITLE
feat: Add Authentication to APIs

### DIFF
--- a/api.py
+++ b/api.py
@@ -22,12 +22,12 @@ def create_user(event, context) -> dict:
 
 
 def add_stock(event, context) -> dict:
-    return AddStock(walter_db).invoke(event)
+    return AddStock(walter_db, sm).invoke(event)
 
 
 def get_stocks_for_user(event, context) -> dict:
-    return GetStocksForUser(walter_db).invoke(event)
+    return GetStocksForUser(walter_db, sm).invoke(event)
 
 
 def send_newsletter(event, context) -> dict:
-    return SendNewsletter(walter_db, newsletters_queue).invoke(event)
+    return SendNewsletter(walter_db, newsletters_queue, sm).invoke(event)

--- a/src/api/add_stock.py
+++ b/src/api/add_stock.py
@@ -1,9 +1,10 @@
 import json
 from dataclasses import dataclass
 
-from src.api.exceptions import UserDoesNotExist, InvalidEmail
+from src.api.exceptions import UserDoesNotExist, InvalidEmail, NotAuthenticated
 from src.api.models import HTTPStatus, Status, create_response
-from src.api.utils import is_valid_email
+from src.api.utils import is_valid_email, authenticate_request
+from src.aws.secretsmanager.client import WalterSecretsManagerClient
 from src.database.client import WalterDB
 from src.database.userstocks.models import UserStock
 from src.utils.log import Logger
@@ -16,9 +17,10 @@ class AddStock:
 
     API_NAME = "WalterAPI: AddStock"
     REQUIRED_FIELDS = ["email", "stock", "quantity"]
-    EXCEPTIONS = [UserDoesNotExist, InvalidEmail]
+    EXCEPTIONS = [NotAuthenticated, UserDoesNotExist, InvalidEmail, NotAuthenticated]
 
     walter_db: WalterDB
+    walter_sm: WalterSecretsManagerClient
 
     def invoke(self, event: dict) -> dict:
         log.info(
@@ -44,14 +46,16 @@ class AddStock:
     def _add_stock(self, event: dict) -> dict:
         try:
             body = json.loads(event["body"])
-
             email = body["email"]
+
             if not is_valid_email(email):
                 raise InvalidEmail("Invalid email!")
 
             user = self.walter_db.get_user(email)
             if user is None:
                 raise UserDoesNotExist("User not found!")
+
+            authenticate_request(event, self.walter_sm.get_jwt_secret_key())
 
             stock = UserStock(
                 user_email=email,

--- a/src/api/auth_user.py
+++ b/src/api/auth_user.py
@@ -60,10 +60,9 @@ class AuthUser:
                 raise InvalidPassword("Password incorrect!")
 
             token = generate_token(email, self._get_jwt_token_key())
-            log.info(f"Authenticated user successfully! Generated token: {token}")
 
             return create_response(
-                AuthUser.API_NAME, HTTPStatus.OK, Status.SUCCESS, "Authenticated user!"
+                AuthUser.API_NAME, HTTPStatus.OK, Status.SUCCESS, token
             )
         except Exception as exception:
             status = HTTPStatus.INTERNAL_SERVER_ERROR

--- a/src/api/exceptions.py
+++ b/src/api/exceptions.py
@@ -21,3 +21,8 @@ class UserAlreadyExists(Exception):
 class UserDoesNotExist(Exception):
     def __init__(self, message):
         super().__init__(message)
+
+
+class NotAuthenticated(Exception):
+    def __init__(self, message):
+        super().__init__(message)

--- a/src/api/send_newsletter.py
+++ b/src/api/send_newsletter.py
@@ -3,7 +3,8 @@ from dataclasses import dataclass
 
 from src.api.exceptions import UserDoesNotExist, InvalidEmail
 from src.api.models import HTTPStatus, Status, create_response
-from src.api.utils import is_valid_email
+from src.api.utils import is_valid_email, authenticate_request
+from src.aws.secretsmanager.client import WalterSecretsManagerClient
 from src.database.client import WalterDB
 from src.newsletters.queue import NewsletterRequest, NewslettersQueue
 from src.utils.log import Logger
@@ -20,6 +21,7 @@ class SendNewsletter:
 
     walter_db: WalterDB
     newsletters_queue: NewslettersQueue
+    walter_sm: WalterSecretsManagerClient
 
     def invoke(self, event: dict) -> dict:
         log.info(
@@ -48,14 +50,16 @@ class SendNewsletter:
     def _send_newsletter(self, event: dict) -> dict:
         try:
             body = json.loads(event["body"])
-
             email = body["email"]
+
             if not is_valid_email(email):
                 raise InvalidEmail("Invalid email!")
 
             user = self.walter_db.get_user(email)
             if user is None:
                 raise UserDoesNotExist("User not found!")
+
+            authenticate_request(event, self.walter_sm.get_jwt_secret_key())
 
             self.newsletters_queue.add_newsletter_request(NewsletterRequest(email))
 

--- a/src/api/utils.py
+++ b/src/api/utils.py
@@ -1,4 +1,8 @@
+import json
 import re
+
+from src.api.exceptions import NotAuthenticated
+from src.utils.auth import decode_token
 
 
 def is_valid_email(email: str) -> bool:
@@ -8,3 +12,26 @@ def is_valid_email(email: str) -> bool:
 
 def is_valid_username(username: str) -> bool:
     return username.isalnum()
+
+
+def authenticate_request(event: dict, key: str) -> bool:
+    token = get_token(event)
+    if token is None:
+        raise NotAuthenticated("Not authenticated!")
+
+    decoded_token = decode_token(token, key)
+    if decoded_token is None:
+        raise NotAuthenticated("Not authenticated!")
+
+    body = json.loads(event["body"])
+    email = body["email"]
+
+    authenticated_user = decoded_token["sub"]
+    if email != authenticated_user:
+        raise NotAuthenticated("Not authenticated!")
+
+
+def get_token(event: dict) -> str:
+    if event["headers"] is None or "Authorization" not in event["headers"]:
+        return None
+    return event["headers"]["Authorization"].split(" ")[1]

--- a/src/utils/auth.py
+++ b/src/utils/auth.py
@@ -19,18 +19,15 @@ def generate_token(email: str, key: str) -> str:
     )
 
 
-def validate_token(token: str, key: str) -> bool:
+def decode_token(token: str, key: str) -> bool:
     try:
-        # Decode the JWT
-        decoded_payload = jwt.decode(token, key, algorithms=[CONFIG.jwt_algorithm])
-        print(f"Decoded payload: {decoded_payload}")
-        return True
+        return jwt.decode(token, key, algorithms=[CONFIG.jwt_algorithm])
     except jwt.ExpiredSignatureError:
         print("Token has expired")
-        return False
+        return None
     except jwt.InvalidTokenError:
         print("Invalid token")
-        return False
+        return None
 
 
 def hash_password(password: str) -> Tuple[bytes, bytes]:

--- a/tst/api/data/event.json
+++ b/tst/api/data/event.json
@@ -2,7 +2,9 @@
     "resource": "/auth",
     "path": "/auth",
     "httpMethod": "POST",
-    "headers": {},
+    "headers": {
+        "Authorization": "Bearer JSON_WEB_TOKEN"
+    },
     "multiValueHeaders": {
         "Accept": [
             "*/*"

--- a/tst/api/test_create_user.py
+++ b/tst/api/test_create_user.py
@@ -4,13 +4,16 @@ import pytest
 
 from src.api.create_user import CreateUser
 from src.api.models import Status, HTTPStatus
+from src.aws.secretsmanager.client import WalterSecretsManagerClient
 from src.database.client import WalterDB
 from tst.api.utils import get_create_user_event
 
 
 @pytest.fixture
-def create_user_api(walter_db: WalterDB) -> CreateUser:
-    return CreateUser(walter_db)
+def create_user_api(
+    walter_db: WalterDB, walter_sm: WalterSecretsManagerClient
+) -> CreateUser:
+    return CreateUser(walter_db, walter_sm)
 
 
 def test_create_user(create_user_api: CreateUser) -> None:

--- a/tst/api/utils.py
+++ b/tst/api/utils.py
@@ -8,13 +8,15 @@ def get_auth_user_event(email: str, password: str) -> dict:
     return EVENT
 
 
-def get_add_stock_event(email: str, stock: str, quantity: float) -> dict:
+def get_add_stock_event(email: str, stock: str, quantity: float, token: str) -> dict:
     EVENT["body"] = json.dumps({"email": email, "stock": stock, "quantity": quantity})
+    EVENT["headers"] = {"Authorization": f"Bearer {token}"}
     return EVENT
 
 
-def get_stocks_for_user_event(email: str) -> dict:
+def get_stocks_for_user_event(email: str, token: str) -> dict:
     EVENT["body"] = json.dumps({"email": email})
+    EVENT["headers"] = {"Authorization": f"Bearer {token}"}
     return EVENT
 
 
@@ -25,6 +27,7 @@ def get_create_user_event(email: str, username: str, password: str) -> dict:
     return EVENT
 
 
-def get_send_newsletter_event(email: str) -> dict:
+def get_send_newsletter_event(email: str, token: str) -> dict:
     EVENT["body"] = json.dumps({"email": email})
+    EVENT["headers"] = {"Authorization": f"Bearer {token}"}
     return EVENT

--- a/tst/conftest.py
+++ b/tst/conftest.py
@@ -17,6 +17,7 @@ from src.database.users.models import User
 from src.database.userstocks.models import UserStock
 from src.environment import Domain
 from src.newsletters.queue import NewslettersQueue
+from src.utils.auth import generate_token
 
 #############
 # CONSTANTS #
@@ -174,3 +175,13 @@ def newsletters_queue(sqs_client) -> NewslettersQueue:
     return NewslettersQueue(
         client=WalterSQSClient(client=sqs_client, domain=Domain.TESTING)
     )
+
+
+@pytest.fixture
+def jwt_walter(walter_sm: WalterSecretsManagerClient) -> str:
+    return generate_token("walter@gmail.com", walter_sm.get_jwt_secret_key())
+
+
+@pytest.fixture
+def jwt_walrus(walter_sm: WalterSecretsManagerClient) -> str:
+    return generate_token("walrus@gmail.com", walter_sm.get_jwt_secret_key())

--- a/tst/utils/test_auth.py
+++ b/tst/utils/test_auth.py
@@ -1,4 +1,4 @@
-from src.utils.auth import hash_password, check_password, generate_token, validate_token
+from src.utils.auth import hash_password, check_password, generate_token, decode_token
 from tst.conftest import SECRETS_MANAGER_JWT_SECRET_KEY_SECRET_VALUE
 
 
@@ -13,8 +13,8 @@ def test_check_password() -> None:
 def test_validate_token() -> None:
     email = "walter@gmail.com"
     token = generate_token(email, SECRETS_MANAGER_JWT_SECRET_KEY_SECRET_VALUE)
-    assert validate_token(token, SECRETS_MANAGER_JWT_SECRET_KEY_SECRET_VALUE) is True
+    decoded_token = decode_token(token, SECRETS_MANAGER_JWT_SECRET_KEY_SECRET_VALUE)
+    assert decoded_token["sub"] == "walter@gmail.com"
     assert (
-        validate_token("test-token", SECRETS_MANAGER_JWT_SECRET_KEY_SECRET_VALUE)
-        is False
+        decode_token("test-token", SECRETS_MANAGER_JWT_SECRET_KEY_SECRET_VALUE) is None
     )


### PR DESCRIPTION
This PR adds authentication to all the APIs that should require authorizing the user before allowing WalterAPI to modify resources owned by the user.

Hmmm, I hope I am not missing anything with this authentication system. Seems like a first good go at it, using standard libraries and keeping keys in SecretsManager.

Good safety to add. 

Will add an `API_KEY` to APIGateway soon to add another layer of protection. 