### PR TITLE
feat: Add GetPortfolio API

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,7 +1,7 @@
 from src.api.add_stock import AddStock
 from src.api.auth_user import AuthUser
 from src.api.create_user import CreateUser
-from src.api.get_stocks_for_user import GetStocksForUser
+from src.api.get_portfolio import GetPortfolio
 from src.api.send_newsletter import SendNewsletter
 from src.clients import walter_db, newsletters_queue, sm, walter_stocks_api, walter_cw
 from src.utils.log import Logger
@@ -25,8 +25,8 @@ def add_stock(event, context) -> dict:
     return AddStock(walter_cw, walter_db, walter_stocks_api, sm).invoke(event)
 
 
-def get_stocks_for_user(event, context) -> dict:
-    return GetStocksForUser(walter_cw, walter_db, sm).invoke(event)
+def get_portfolio(event, context) -> dict:
+    return GetPortfolio(walter_cw, walter_db, sm, walter_stocks_api).invoke(event)
 
 
 def send_newsletter(event, context) -> dict:

--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -202,32 +202,32 @@ Resources:
       FunctionName: !Ref WalterAPIAddStock
       Principal: apigateway.amazonaws.com
 
-  WalterAPIGetStocksForUserResource:
+  WalterAPIGetPortfolioResource:
     Type: AWS::ApiGateway::Resource
     Properties:
-      ParentId: !Ref WalterAPIUsers
+      ParentId: !GetAtt WalterAPIGateway.RootResourceId
       RestApiId: !Ref WalterAPIGateway
-      PathPart: stocks
+      PathPart: portfolios
 
-  WalterAPIGetStocksForUserMethod:
+  WalterAPIGetPortfolioMethod:
     Type: AWS::ApiGateway::Method
     Properties:
       HttpMethod: POST
-      ResourceId: !Ref WalterAPIGetStocksForUserResource
+      ResourceId: !Ref WalterAPIGetPortfolioResource
       RestApiId: !Ref WalterAPIGateway
       AuthorizationType: NONE
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${WalterAPIGetStocksForUser.Arn}/invocations"
+        Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${WalterAPIGetPortfolio.Arn}/invocations"
       MethodResponses:
         - StatusCode: 200
 
-  WalterAPIGetStocksForUserCORSMethod:
+  WalterAPIGetPortfolioCORSMethod:
     Type: AWS::ApiGateway::Method
     Properties:
       RestApiId: !Ref WalterAPIGateway
-      ResourceId: !Ref WalterAPIGetStocksForUserResource
+      ResourceId: !Ref WalterAPIGetPortfolioResource
       HttpMethod: OPTIONS
       AuthorizationType: NONE
       Integration:
@@ -252,11 +252,11 @@ Resources:
             method.response.header.Access-Control-Allow-Methods: false
             method.response.header.Access-Control-Allow-Origin: false
 
-  WalterAPIGetStocksForUserPermission:
+  WalterAPIGetPortfolioPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !Ref WalterAPIGetStocksForUser
+      FunctionName: !Ref WalterAPIGetPortfolio
       Principal: apigateway.amazonaws.com
 
   WalterAPISendNewsletterPermission:
@@ -422,19 +422,19 @@ Resources:
         Variables:
           DOMAIN: DEVELOPMENT
 
-  WalterAPIGetStocksForUserAlias:
+  WalterAPIGetPortfolioAlias:
     Type: AWS::Lambda::Alias
     Properties:
-      FunctionName: !Ref WalterAPIGetStocksForUser
+      FunctionName: !Ref WalterAPIGetPortfolio
       FunctionVersion: $LATEST
-      Name: !Sub "WalterAPI-GetStocksForUser-${AppEnvironment}"
+      Name: !Sub "WalterAPI-GetPortfolio-${AppEnvironment}"
 
-  WalterAPIGetStocksForUser:
+  WalterAPIGetPortfolio:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub "WalterAPI-GetStocksForUser-${AppEnvironment}"
-      Description: !Sub "WalterAPI: GetStocksForUser - Get stocks for the given user from WalterDB (${AppEnvironment})"
-      Handler: api.get_stocks_for_user
+      FunctionName: !Sub "WalterAPI-GetPortfolio-${AppEnvironment}"
+      Description: !Sub "WalterAPI: GetPortfolio - Get user portfolio with latest market data (${AppEnvironment})"
+      Handler: api.get_portfolio
       Role: !GetAtt WalterAPIRole.Arn
       Code:
         S3Bucket: walter-backend-src
@@ -953,7 +953,7 @@ Outputs:
     Value: !Sub "https://${WalterAPIGateway}.execute-api.${AWS::Region}.amazonaws.com/${AppEnvironment}/users"
   WalterAPIAddStockEndpoint:
     Value: !Sub "https://${WalterAPIGateway}.execute-api.${AWS::Region}.amazonaws.com/${AppEnvironment}/stocks"
-  WalterAPIGetStocksForUserEndpoint:
-    Value: !Sub "https://${WalterAPIGateway}.execute-api.${AWS::Region}.amazonaws.com/${AppEnvironment}/users/stocks"
+  WalterAPIGetPortfolioEndpoint:
+    Value: !Sub "https://${WalterAPIGateway}.execute-api.${AWS::Region}.amazonaws.com/${AppEnvironment}/portfolios"
   WalterAPISendNewsletterEndpoint:
     Value: !Sub "https://${WalterAPIGateway}.execute-api.${AWS::Region}.amazonaws.com/${AppEnvironment}/newsletters"

--- a/scripts/update-lambda-versions.sh
+++ b/scripts/update-lambda-versions.sh
@@ -4,8 +4,8 @@ echo Publishing new WalterAPI Auth Lambda version \
 && aws lambda publish-version --function-name WalterAPI-CreateUser-dev \
 && echo Publishing new WalterAPI AddStock Lambda version \
 && aws lambda publish-version --function-name WalterAPI-AddStock-dev \
-&& echo Publishing new WalterAPI GetStocksForUser Lambda version \
-&& aws lambda publish-version --function-name WalterAPI-GetStocksForUser-dev \
+&& echo Publishing new WalterAPI GetPortfolio Lambda version \
+&& aws lambda publish-version --function-name WalterAPI-GetPortfolio-dev \
 && echo Publishing new WalterAPI SendNewsletter Lambda version \
 && aws lambda publish-version --function-name WalterAPI-SendNewsletter-dev \
 && echo Publishing new WalterNewsletters Lambda version \

--- a/scripts/update-lambdas.sh
+++ b/scripts/update-lambdas.sh
@@ -4,8 +4,8 @@ echo Updating WalterAPI Auth source code with artifact from S3 \
 && aws lambda update-function-code --function-name WalterAPI-CreateUser-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip \
 && echo Updating WalterAPI AddStock source code with artifact from S3 \
 && aws lambda update-function-code --function-name WalterAPI-AddStock-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip \
-&& echo Updating WalterAPI GetStocksForUser source code with artifact from S3 \
-&& aws lambda update-function-code --function-name WalterAPI-GetStocksForUser-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip \
+&& echo Updating WalterAPI GetPortfolio source code with artifact from S3 \
+&& aws lambda update-function-code --function-name WalterAPI-GetPortfolio-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip \
 && echo Updating WalterAPI SendNewsletter source code with artifact from S3 \
 && aws lambda update-function-code --function-name WalterAPI-SendNewsletter-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip \
 && echo Updating WalterNewsletters source code with artifact from S3 \

--- a/src/api/get_portfolio.py
+++ b/src/api/get_portfolio.py
@@ -1,5 +1,6 @@
 import json
 from dataclasses import dataclass
+import datetime as dt
 
 from src.api.exceptions import UserDoesNotExist, InvalidEmail
 from src.api.methods import WalterAPIMethod
@@ -8,15 +9,16 @@ from src.api.utils import is_valid_email
 from src.aws.cloudwatch.client import WalterCloudWatchClient
 from src.aws.secretsmanager.client import WalterSecretsManagerClient
 from src.database.client import WalterDB
+from src.stocks.client import WalterStocksAPI
 from src.utils.log import Logger
 
 log = Logger(__name__).get_logger()
 
 
 @dataclass
-class GetStocksForUser(WalterAPIMethod):
+class GetPortfolio(WalterAPIMethod):
 
-    API_NAME = "GetStocksForUser"
+    API_NAME = "GetPortfolio"
     REQUIRED_FIELDS = ["email"]
     EXCEPTIONS = [InvalidEmail, UserDoesNotExist]
 
@@ -28,15 +30,17 @@ class GetStocksForUser(WalterAPIMethod):
         walter_cw: WalterCloudWatchClient,
         walter_db: WalterDB,
         walter_sm: WalterSecretsManagerClient,
+        walter_stocks_api: WalterStocksAPI,
     ) -> None:
         super().__init__(
-            GetStocksForUser.API_NAME,
-            GetStocksForUser.REQUIRED_FIELDS,
-            GetStocksForUser.EXCEPTIONS,
+            GetPortfolio.API_NAME,
+            GetPortfolio.REQUIRED_FIELDS,
+            GetPortfolio.EXCEPTIONS,
             walter_cw,
         )
         self.walter_db = walter_db
         self.walter_sm = walter_sm
+        self.walter_stocks_api = walter_stocks_api
 
     def execute(self, event: dict) -> dict:
         body = json.loads(event["body"])
@@ -48,10 +52,14 @@ class GetStocksForUser(WalterAPIMethod):
 
         stocks = self.walter_db.get_stocks_for_user(user)
 
+        end = dt.datetime.now(dt.UTC)
+        start = end - dt.timedelta(days=7)
+        portfolio = self.walter_stocks_api.get_portfolio(stocks, start, end)
+
         return self._create_response(
             HTTPStatus.OK,
             Status.SUCCESS,
-            [stock.to_dict() for stock in stocks.values()],
+            [stock.to_dict() for stock in portfolio.get_stock_equities()],
         )
 
     def validate_fields(self, event: dict) -> None:

--- a/src/stocks/models.py
+++ b/src/stocks/models.py
@@ -5,6 +5,22 @@ from src.database.userstocks.models import UserStock
 from src.stocks.polygon.models import StockPrices, StockNews
 
 
+@dataclass(frozen=True)
+class StockEquity:
+    symbol: str
+    price: float
+    quantity: float
+    equity: float
+
+    def to_dict(self) -> dict:
+        return {
+            "symbol": self.symbol,
+            "price": self.price,
+            "quantity": self.quantity,
+            "equity": self.equity,
+        }
+
+
 @dataclass
 class Portfolio:
 
@@ -34,3 +50,12 @@ class Portfolio:
 
     def get_news(self, symbol: str) -> str:
         return self.news[symbol]
+
+    def get_stock_equities(self) -> List[StockEquity]:
+        stock_equities = []
+        for stock in self.stocks.keys():
+            price = self.get_latest_price(stock)
+            quantity = self.get_number_of_shares(stock)
+            equity = self.get_equity(stock)
+            stock_equities.append(StockEquity(stock, price, quantity, equity))
+        return stock_equities

--- a/tst/api/test_get_portfolio.py
+++ b/tst/api/test_get_portfolio.py
@@ -2,59 +2,48 @@ import json
 
 import pytest
 
-from src.api.get_stocks_for_user import GetStocksForUser
+from src.api.get_portfolio import GetPortfolio
 from src.api.models import Status, HTTPStatus
 from src.aws.cloudwatch.client import WalterCloudWatchClient
 from src.aws.secretsmanager.client import WalterSecretsManagerClient
 from src.database.client import WalterDB
-from tst.api.utils import get_stocks_for_user_event
+from src.stocks.client import WalterStocksAPI
+from tst.api.utils import get_portfolio_event
 
 
 @pytest.fixture
-def get_stocks_for_user_api(
+def get_portfolio_api(
     walter_cw: WalterCloudWatchClient,
     walter_db: WalterDB,
     walter_sm: WalterSecretsManagerClient,
-) -> GetStocksForUser:
-    return GetStocksForUser(walter_cw, walter_db, walter_sm)
+    walter_stocks_api: WalterStocksAPI,
+) -> GetPortfolio:
+    return GetPortfolio(walter_cw, walter_db, walter_sm, walter_stocks_api)
 
 
 def test_get_stocks_for_user(
-    get_stocks_for_user_api: GetStocksForUser, walter_db: WalterDB, jwt_walrus: str
+    get_portfolio_api: GetPortfolio, walter_db: WalterDB, jwt_walrus: str
 ) -> None:
-    event = get_stocks_for_user_event(email="walrus@gmail.com", token=jwt_walrus)
+    event = get_portfolio_event(email="walrus@gmail.com", token=jwt_walrus)
     expected_response = get_expected_response(
         status_code=HTTPStatus.OK,
         status=Status.SUCCESS,
         message=[
-            {
-                "user_email": "walrus@gmail.com",
-                "stock_symbol": "AMZN",
-                "quantity": 100.0,
-            },
-            {
-                "user_email": "walrus@gmail.com",
-                "stock_symbol": "MSFT",
-                "quantity": 100.0,
-            },
-            {
-                "user_email": "walrus@gmail.com",
-                "stock_symbol": "NFLX",
-                "quantity": 100.0,
-            },
+            {"symbol": "AAPL", "price": 100.0, "quantity": 100.0, "equity": 10000.0},
+            {"symbol": "META", "price": 250.0, "quantity": 100.0, "equity": 25000.0},
         ],
     )
-    assert expected_response == get_stocks_for_user_api.invoke(event)
+    assert expected_response == get_portfolio_api.invoke(event)
 
 
 def test_add_stock_failure_invalid_email(
-    get_stocks_for_user_api: GetStocksForUser, jwt_walter: str
+    get_portfolio_api: GetPortfolio, jwt_walter: str
 ) -> None:
-    event = get_stocks_for_user_event(email="walter", token=jwt_walter)
+    event = get_portfolio_event(email="walter", token=jwt_walter)
     expected_response = get_expected_response(
         status_code=HTTPStatus.OK, status=Status.FAILURE, message="Invalid email!"
     )
-    assert expected_response == get_stocks_for_user_api.invoke(event)
+    assert expected_response == get_portfolio_api.invoke(event)
 
 
 def get_expected_response(
@@ -70,7 +59,7 @@ def get_expected_response(
         },
         "body": json.dumps(
             {
-                "API": "GetStocksForUser",
+                "API": "GetPortfolio",
                 "Status": status.value,
                 "Message": message,
             }

--- a/tst/api/utils.py
+++ b/tst/api/utils.py
@@ -14,7 +14,7 @@ def get_add_stock_event(email: str, stock: str, quantity: float, token: str) -> 
     return EVENT
 
 
-def get_stocks_for_user_event(email: str, token: str) -> dict:
+def get_portfolio_event(email: str, token: str) -> dict:
     EVENT["body"] = json.dumps({"email": email})
     EVENT["headers"] = {"Authorization": f"Bearer {token}"}
     return EVENT

--- a/tst/database/data/usersstocks.jsonl
+++ b/tst/database/data/usersstocks.jsonl
@@ -3,6 +3,5 @@
 {"user_email": "walter@gmail.com", "stock_symbol": "MSFT", "quantity": 2.0}
 {"user_email": "walter@gmail.com", "stock_symbol": "NFLX", "quantity": 10.0}
 {"user_email": "walter@gmail.com", "stock_symbol": "PYPL", "quantity": 10.0}
-{"user_email": "walrus@gmail.com", "stock_symbol": "AMZN", "quantity": 100.0}
-{"user_email": "walrus@gmail.com", "stock_symbol": "MSFT", "quantity": 100.0}
-{"user_email": "walrus@gmail.com", "stock_symbol": "NFLX", "quantity": 100.0}
+{"user_email": "walrus@gmail.com", "stock_symbol": "AAPL", "quantity": 100.0}
+{"user_email": "walrus@gmail.com", "stock_symbol": "META", "quantity": 100.0}

--- a/tst/database/test_walter_db.py
+++ b/tst/database/test_walter_db.py
@@ -17,9 +17,8 @@ WALTER_STOCKS = [
     UserStock(user_email=WALTER.email, stock_symbol="PYPL", quantity=10.0),
 ]
 WALRUS_STOCKS = [
-    UserStock(user_email=WALRUS.email, stock_symbol="AMZN", quantity=100.0),
-    UserStock(user_email=WALRUS.email, stock_symbol="MSFT", quantity=100.0),
-    UserStock(user_email=WALRUS.email, stock_symbol="NFLX", quantity=100.0),
+    UserStock(user_email=WALRUS.email, stock_symbol="AAPL", quantity=100.0),
+    UserStock(user_email=WALRUS.email, stock_symbol="META", quantity=100.0),
 ]
 
 


### PR DESCRIPTION
This PR adds the `GetPortfolio` API.

This API is meant to replace the `GetStocksForUser` API since that just returned stocks for a given user which isn't incredibly helpful...

This API aims to be more data-rich so that the UI can display pie charts and other helpful visual aid about portfolio.

More into the details, this API merges the results in WalterDB and from Polygon to get a portfolio of the users stocks and the latest market data.